### PR TITLE
Implement basic Flask skeleton for OpenBBS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+uploads/*
+!uploads/.gitkeep

--- a/README.md
+++ b/README.md
@@ -1,2 +1,34 @@
-# hambbs
-a bbs system for ham radio
+# OpenBBS
+
+A simple Bulletin Board System implemented in Python using Flask. It provides user authentication and message posting with basic forum support.
+
+## Features
+
+- User signup and login
+- Forums with threads and replies
+- File attachments on posts
+- Reputation system with post upvoting
+- User profiles with editable bios
+- SQLite database via SQLAlchemy
+- Simple web interface using Bootstrap
+
+## Setup
+
+1. Create a Python virtual environment (optional but recommended)
+2. Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+3. Run the application:
+
+```bash
+python run.py
+```
+
+Then open `http://localhost:5000` in your browser.
+
+## Notes
+
+This project is still a prototype. Advanced features such as COM/VaraHF integration, a dedicated client, and encrypted file storage are not implemented.

--- a/openbbs/__init__.py
+++ b/openbbs/__init__.py
@@ -1,0 +1,36 @@
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+from flask_login import LoginManager
+from pathlib import Path
+
+# Database instance
+DB_NAME = 'openbbs.db'
+db = SQLAlchemy()
+login_manager = LoginManager()
+login_manager.login_view = 'auth.login'
+
+
+def create_app():
+    app = Flask(__name__)
+    app.config['SECRET_KEY'] = 'change-this-secret-key'
+    app.config['SQLALCHEMY_DATABASE_URI'] = f'sqlite:///{DB_NAME}'
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    app.config['UPLOAD_FOLDER'] = str(Path('uploads'))
+
+    db.init_app(app)
+    login_manager.init_app(app)
+
+    from .models import User, Post, Forum, Attachment
+
+    with app.app_context():
+        Path(app.config['UPLOAD_FOLDER']).mkdir(exist_ok=True)
+        db.create_all()
+
+    from .auth import auth_bp
+    from .views import main_bp
+    from .forums import forums_bp
+    app.register_blueprint(auth_bp)
+    app.register_blueprint(main_bp)
+    app.register_blueprint(forums_bp)
+
+    return app

--- a/openbbs/auth.py
+++ b/openbbs/auth.py
@@ -1,0 +1,49 @@
+from flask import Blueprint, render_template, redirect, url_for, request, flash
+from werkzeug.security import generate_password_hash, check_password_hash
+from flask_login import login_user, login_required, logout_user
+from .models import User
+from . import db
+
+auth_bp = Blueprint('auth', __name__)
+
+
+@auth_bp.route('/login', methods=['GET', 'POST'])
+def login():
+    if request.method == 'POST':
+        username = request.form.get('username')
+        password = request.form.get('password')
+        user = User.query.filter_by(username=username).first()
+        if user and check_password_hash(user.password, password):
+            login_user(user)
+            return redirect(url_for('main.index'))
+        flash('Invalid credentials')
+    return render_template('login.html')
+
+
+@auth_bp.route('/signup', methods=['GET', 'POST'])
+def signup():
+    if request.method == 'POST':
+        username = request.form.get('username')
+        password = request.form.get('password')
+        bio = request.form.get('bio')
+        if username and password:
+            existing = User.query.filter_by(username=username).first()
+            if existing:
+                flash('User already exists')
+            else:
+                user = User(username=username,
+                            password=generate_password_hash(password),
+                            bio=bio or '')
+                db.session.add(user)
+                db.session.commit()
+                login_user(user)
+                return redirect(url_for('main.index'))
+        flash('Invalid input')
+    return render_template('signup.html')
+
+
+@auth_bp.route('/logout')
+@login_required
+def logout():
+    logout_user()
+    return redirect(url_for('auth.login'))

--- a/openbbs/forums.py
+++ b/openbbs/forums.py
@@ -1,0 +1,35 @@
+from flask import Blueprint, render_template, request, redirect, url_for
+from flask_login import login_required
+from .models import Forum, Post
+from . import db
+
+forums_bp = Blueprint('forums', __name__, url_prefix='/forums')
+
+
+@forums_bp.route('/')
+@login_required
+def list_forums():
+    forums = Forum.query.all()
+    return render_template('forums.html', forums=forums)
+
+
+@forums_bp.route('/create', methods=['GET', 'POST'])
+@login_required
+def create_forum():
+    if request.method == 'POST':
+        name = request.form.get('name')
+        description = request.form.get('description')
+        if name:
+            f = Forum(name=name, description=description or '')
+            db.session.add(f)
+            db.session.commit()
+            return redirect(url_for('forums.list_forums'))
+    return render_template('create_forum.html')
+
+
+@forums_bp.route('/<int:forum_id>')
+@login_required
+def view_forum(forum_id):
+    forum = Forum.query.get_or_404(forum_id)
+    posts = Post.query.filter_by(forum_id=forum_id, parent_id=None).order_by(Post.timestamp.desc()).all()
+    return render_template('forum_view.html', forum=forum, posts=posts)

--- a/openbbs/models.py
+++ b/openbbs/models.py
@@ -1,0 +1,58 @@
+from . import db, login_manager
+from flask_login import UserMixin
+from datetime import datetime
+from sqlalchemy import UniqueConstraint
+
+
+class User(db.Model, UserMixin):
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(150), unique=True, nullable=False)
+    password = db.Column(db.String(150), nullable=False)
+    bio = db.Column(db.Text, default="")
+    reputation = db.Column(db.Integer, default=0)
+    posts = db.relationship('Post', backref='author', lazy=True)
+    upvotes = db.relationship('Upvote', backref='user', lazy=True)
+
+
+class Forum(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(150), unique=True, nullable=False)
+    description = db.Column(db.Text, default="")
+    posts = db.relationship('Post', backref='forum', lazy=True)
+
+
+class Post(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(255), nullable=False)
+    body = db.Column(db.Text, nullable=False)
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    forum_id = db.Column(db.Integer, db.ForeignKey('forum.id'), nullable=False)
+    parent_id = db.Column(db.Integer, db.ForeignKey('post.id'))
+    children = db.relationship('Post', backref=db.backref('parent', remote_side=[id]), lazy=True)
+    attachments = db.relationship('Attachment', backref='post', lazy=True)
+    upvotes = db.relationship('Upvote', backref='post', lazy=True)
+
+    @property
+    def score(self):
+        return len(self.upvotes)
+
+
+class Attachment(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    filename = db.Column(db.String(255), nullable=False)
+    original_name = db.Column(db.String(255), nullable=False)
+    post_id = db.Column(db.Integer, db.ForeignKey('post.id'), nullable=False)
+
+
+class Upvote(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    post_id = db.Column(db.Integer, db.ForeignKey('post.id'), nullable=False)
+    __table_args__ = (db.UniqueConstraint('user_id', 'post_id',
+                                         name='unique_upvote'),)
+
+
+@login_manager.user_loader
+def load_user(user_id):
+    return User.query.get(int(user_id))

--- a/openbbs/templates/base.html
+++ b/openbbs/templates/base.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>OpenBBS</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-light bg-light mb-3">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="{{ url_for('main.index') }}">OpenBBS</a>
+    <div class="collapse navbar-collapse">
+      <ul class="navbar-nav ms-auto">
+        <li class="nav-item">
+          <a class="nav-link" href="{{ url_for('main.index') }}">Forums</a>
+        </li>
+        {% if current_user.is_authenticated %}
+        <li class="nav-item">
+          <a class="nav-link" href="{{ url_for('main.profile', username=current_user.username) }}">Profile</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="{{ url_for('auth.logout') }}">Logout</a>
+        </li>
+        {% else %}
+        <li class="nav-item">
+          <a class="nav-link" href="{{ url_for('auth.login') }}">Login</a>
+        </li>
+        {% endif %}
+      </ul>
+    </div>
+  </div>
+</nav>
+<div class="container">
+{% with messages = get_flashed_messages() %}
+  {% if messages %}
+  <div class="alert alert-danger" role="alert">
+    {{ messages[0] }}
+  </div>
+  {% endif %}
+{% endwith %}
+{% block content %}{% endblock %}
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/openbbs/templates/create_forum.html
+++ b/openbbs/templates/create_forum.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Create Forum</h2>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Name</label>
+    <input class="form-control" type="text" name="name" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Description</label>
+    <textarea class="form-control" name="description" rows="3"></textarea>
+  </div>
+  <button class="btn btn-success" type="submit">Create</button>
+</form>
+{% endblock %}

--- a/openbbs/templates/edit_profile.html
+++ b/openbbs/templates/edit_profile.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Edit Profile</h2>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Bio</label>
+    <textarea class="form-control" name="bio" rows="4">{{ user.bio }}</textarea>
+  </div>
+  <button class="btn btn-primary" type="submit">Save</button>
+</form>
+{% endblock %}

--- a/openbbs/templates/forum_view.html
+++ b/openbbs/templates/forum_view.html
@@ -1,0 +1,62 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>{{ forum.name }}</h2>
+<p>{{ forum.description }}</p>
+<form method="post" action="{{ url_for('main.create_post') }}" enctype="multipart/form-data" class="mb-3">
+  <input type="hidden" name="forum_id" value="{{ forum.id }}">
+  <div class="mb-3">
+    <input class="form-control" type="text" name="title" placeholder="Title" required>
+  </div>
+  <div class="mb-3">
+    <textarea class="form-control" name="body" rows="4" placeholder="Message" required></textarea>
+  </div>
+  <div class="mb-3">
+    <input class="form-control" type="file" name="attachment">
+  </div>
+  <button class="btn btn-success" type="submit">Post</button>
+</form>
+<ul class="list-group">
+  {% for post in posts %}
+  <li class="list-group-item">
+    <h5>{{ post.title }} <small class="text-muted">by {{ post.author.username }} at {{ post.timestamp.strftime('%Y-%m-%d %H:%M') }}</small>
+        <span class="badge bg-secondary">{{ post.score }}</span>
+    </h5>
+    <form method="post" action="{{ url_for('main.upvote', post_id=post.id) }}" class="d-inline">
+      <button class="btn btn-sm btn-outline-primary" type="submit">Upvote</button>
+    </form>
+    <p>{{ post.body }}</p>
+    {% for att in post.attachments %}
+    <p><a href="{{ url_for('main.get_attachment', att_id=att.id) }}">{{ att.original_name }}</a></p>
+    {% endfor %}
+    {% for reply in post.children %}
+    <div class="mt-3 ms-3 border-start ps-3">
+      <h6>{{ reply.title }} <small class="text-muted">by {{ reply.author.username }} at {{ reply.timestamp.strftime('%Y-%m-%d %H:%M') }}</small>
+          <span class="badge bg-secondary">{{ reply.score }}</span>
+      </h6>
+      <form method="post" action="{{ url_for('main.upvote', post_id=reply.id) }}" class="d-inline">
+        <button class="btn btn-sm btn-outline-primary" type="submit">Upvote</button>
+      </form>
+      <p>{{ reply.body }}</p>
+      {% for ratt in reply.attachments %}
+      <p><a href="{{ url_for('main.get_attachment', att_id=ratt.id) }}">{{ ratt.original_name }}</a></p>
+      {% endfor %}
+    </div>
+    {% endfor %}
+    <form method="post" action="{{ url_for('main.create_post') }}" enctype="multipart/form-data" class="mt-3">
+      <input type="hidden" name="forum_id" value="{{ forum.id }}">
+      <input type="hidden" name="parent_id" value="{{ post.id }}">
+      <div class="mb-2">
+        <input class="form-control" type="text" name="title" placeholder="Reply title" required>
+      </div>
+      <div class="mb-2">
+        <textarea class="form-control" name="body" rows="2" placeholder="Reply" required></textarea>
+      </div>
+      <div class="mb-2">
+        <input class="form-control" type="file" name="attachment">
+      </div>
+      <button class="btn btn-secondary btn-sm" type="submit">Reply</button>
+    </form>
+  </li>
+  {% endfor %}
+</ul>
+{% endblock %}

--- a/openbbs/templates/forums.html
+++ b/openbbs/templates/forums.html
@@ -1,0 +1,13 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Forums</h2>
+<a class="btn btn-primary mb-3" href="{{ url_for('forums.create_forum') }}">Create Forum</a>
+<ul class="list-group">
+  {% for f in forums %}
+  <li class="list-group-item">
+    <a href="{{ url_for('forums.view_forum', forum_id=f.id) }}">{{ f.name }}</a>
+    <p class="small text-muted">{{ f.description }}</p>
+  </li>
+  {% endfor %}
+</ul>
+{% endblock %}

--- a/openbbs/templates/index.html
+++ b/openbbs/templates/index.html
@@ -1,0 +1,21 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Message Board</h2>
+<form method="post" action="{{ url_for('main.create_post') }}" class="mb-3">
+  <div class="mb-3">
+    <input class="form-control" type="text" name="title" placeholder="Title" required>
+  </div>
+  <div class="mb-3">
+    <textarea class="form-control" name="body" rows="4" placeholder="Message" required></textarea>
+  </div>
+  <button class="btn btn-success" type="submit">Post</button>
+</form>
+<ul class="list-group">
+  {% for post in posts %}
+  <li class="list-group-item">
+    <h5>{{ post.title }} <small class="text-muted">by {{ post.author.username }} at {{ post.timestamp.strftime('%Y-%m-%d %H:%M') }}</small></h5>
+    <p>{{ post.body }}</p>
+  </li>
+  {% endfor %}
+</ul>
+{% endblock %}

--- a/openbbs/templates/login.html
+++ b/openbbs/templates/login.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Login</h2>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Username</label>
+    <input class="form-control" type="text" name="username" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Password</label>
+    <input class="form-control" type="password" name="password" required>
+  </div>
+  <button class="btn btn-primary" type="submit">Login</button>
+  <a href="{{ url_for('auth.signup') }}" class="ms-2">Signup</a>
+</form>
+{% endblock %}

--- a/openbbs/templates/profile.html
+++ b/openbbs/templates/profile.html
@@ -1,0 +1,18 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>{{ user.username }}'s Profile</h2>
+<p>{{ user.bio }}</p>
+<p>Reputation: {{ user.reputation }}</p>
+{% if current_user.id == user.id %}
+<a class="btn btn-secondary mb-3" href="{{ url_for('main.edit_profile') }}">Edit Profile</a>
+{% endif %}
+<h3>Posts</h3>
+<ul class="list-group">
+  {% for p in posts %}
+  <li class="list-group-item">
+    <a href="{{ url_for('forums.view_forum', forum_id=p.forum.id) }}">{{ p.title }}</a>
+    <small class="text-muted">in {{ p.forum.name }} at {{ p.timestamp.strftime('%Y-%m-%d %H:%M') }}</small>
+  </li>
+  {% endfor %}
+</ul>
+{% endblock %}

--- a/openbbs/templates/signup.html
+++ b/openbbs/templates/signup.html
@@ -1,0 +1,20 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Signup</h2>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Username</label>
+    <input class="form-control" type="text" name="username" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Password</label>
+    <input class="form-control" type="password" name="password" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Bio</label>
+    <textarea class="form-control" name="bio" rows="3"></textarea>
+  </div>
+  <button class="btn btn-primary" type="submit">Signup</button>
+  <a href="{{ url_for('auth.login') }}" class="ms-2">Login</a>
+</form>
+{% endblock %}

--- a/openbbs/views.py
+++ b/openbbs/views.py
@@ -1,0 +1,82 @@
+from flask import Blueprint, render_template, request, redirect, url_for, current_app, send_from_directory
+from flask_login import login_required, current_user
+from .models import Post, Forum, Attachment, User, Upvote
+from . import db
+from werkzeug.utils import secure_filename
+from pathlib import Path
+
+main_bp = Blueprint('main', __name__)
+
+
+@main_bp.route('/')
+@login_required
+def index():
+    forums = Forum.query.all()
+    return render_template('forums.html', forums=forums)
+
+
+@main_bp.route('/post', methods=['POST'])
+@login_required
+def create_post():
+    title = request.form.get('title')
+    body = request.form.get('body')
+    forum_id = request.form.get('forum_id', type=int)
+    parent_id = request.form.get('parent_id', type=int)
+    if title and body and forum_id:
+        post = Post(title=title, body=body, author=current_user,
+                    forum_id=forum_id, parent_id=parent_id)
+        db.session.add(post)
+        db.session.flush()  # to get id before committing
+        file = request.files.get('attachment')
+        if file and file.filename:
+            filename = secure_filename(file.filename)
+            upload_folder = Path(current_app.config['UPLOAD_FOLDER'])
+            dest = upload_folder / f"{post.id}_{filename}"
+            file.save(dest)
+            att = Attachment(filename=str(dest), original_name=filename, post=post)
+            db.session.add(att)
+        db.session.commit()
+    if forum_id:
+        return redirect(url_for('forums.view_forum', forum_id=forum_id))
+    return redirect(url_for('main.index'))
+
+
+@main_bp.route('/attachment/<int:att_id>')
+@login_required
+def get_attachment(att_id):
+    att = Attachment.query.get_or_404(att_id)
+    path = Path(att.filename)
+    return send_from_directory(path.parent, path.name, as_attachment=True,
+                               download_name=att.original_name)
+
+
+@main_bp.route('/profile/<username>')
+@login_required
+def profile(username):
+    user = User.query.filter_by(username=username).first_or_404()
+    posts = Post.query.filter_by(user_id=user.id).order_by(Post.timestamp.desc()).all()
+    return render_template('profile.html', user=user, posts=posts)
+
+
+@main_bp.route('/profile/edit', methods=['GET', 'POST'])
+@login_required
+def edit_profile():
+    if request.method == 'POST':
+        bio = request.form.get('bio', '')
+        current_user.bio = bio
+        db.session.commit()
+        return redirect(url_for('main.profile', username=current_user.username))
+    return render_template('edit_profile.html', user=current_user)
+
+
+@main_bp.route('/upvote/<int:post_id>', methods=['POST'])
+@login_required
+def upvote(post_id):
+    post = Post.query.get_or_404(post_id)
+    existing = Upvote.query.filter_by(user_id=current_user.id, post_id=post_id).first()
+    if not existing:
+        up = Upvote(user_id=current_user.id, post_id=post_id)
+        db.session.add(up)
+        post.author.reputation += 1
+        db.session.commit()
+    return redirect(request.referrer or url_for('main.index'))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+flask
+flask_sqlalchemy
+flask_login
+werkzeug

--- a/run.py
+++ b/run.py
@@ -1,0 +1,6 @@
+from openbbs import create_app
+
+app = create_app()
+
+if __name__ == '__main__':
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- create a `run.py` launcher and Flask app factory
- implement simple models (User, Post) using SQLAlchemy
- add authentication routes and message posting views
- provide minimal Bootstrap-based templates
- document setup steps and limitations in `README`
- include requirements file
- add upvote and reputation support with editable user bios

## Testing
- `python -m py_compile run.py openbbs/*.py`
- `python run.py` *(startup verified)*

------
https://chatgpt.com/codex/tasks/task_b_687e752c1544832a92725a127cdf73c5