### PR TITLE
Add sync engine, CLI queue, and tests

### DIFF
--- a/bbs.py
+++ b/bbs.py
@@ -1,0 +1,102 @@
+import argparse
+import sys
+import uuid
+from datetime import datetime
+from pathlib import Path
+import tempfile
+
+from db import init_db, connect
+from sync import SyncEngine
+
+DB_PATH = Path('openbbs.db')
+
+
+def cmd_sync_pull(args):
+    engine = SyncEngine(str(DB_PATH))
+    with tempfile.NamedTemporaryFile(suffix='.tar.zst', delete=False) as tmp:
+        path = tmp.name if args.output == '-' else args.output or tmp.name
+    engine.pull(since=args.since, thread_ids=args.thread, output_path=path)
+    if args.output == '-':
+        with open(path, 'rb') as f:
+            sys.stdout.buffer.write(f.read())
+        Path(path).unlink(missing_ok=True)
+    else:
+        print(path)
+
+
+def cmd_sync_push(args):
+    engine = SyncEngine(str(DB_PATH))
+    summary = engine.push(args.package)
+    print(summary)
+
+
+def cmd_queue_post(args):
+    body = args.body
+    if not body:
+        body = sys.stdin.read()
+    tid = args.thread_id
+    init_db(DB_PATH)
+    conn = connect(DB_PATH)
+    cur = conn.cursor()
+    mid = str(uuid.uuid4())
+    ts = datetime.utcnow().isoformat()
+    cur.execute(
+        "INSERT INTO outbox (id, thread_id, body, queued_at) VALUES (?,?,?,?)",
+        (mid, tid, body, ts)
+    )
+    conn.commit()
+    conn.close()
+    print(mid)
+
+
+def cmd_outbox_view(_):
+    init_db(DB_PATH)
+    conn = connect(DB_PATH)
+    cur = conn.cursor()
+    rows = cur.execute("SELECT id, thread_id, queued_at, body FROM outbox ORDER BY queued_at").fetchall()
+    for r in rows:
+        snippet = r['body'][:80].replace('\n', ' ')
+        print(f"{r['id']} {r['thread_id']} {r['queued_at']} {snippet}")
+    conn.close()
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Hambbs CLI')
+    sub = parser.add_subparsers(dest='command')
+
+    sync = sub.add_parser('sync')
+    sync_sub = sync.add_subparsers(dest='sync_cmd')
+
+    pull = sync_sub.add_parser('pull')
+    pull.add_argument('--since')
+    pull.add_argument('--thread', nargs='*')
+    pull.add_argument('output', nargs='?', default='sync.tar.zst')
+    pull.set_defaults(func=cmd_sync_pull)
+
+    push = sync_sub.add_parser('push')
+    push.add_argument('package')
+    push.set_defaults(func=cmd_sync_push)
+
+    queue = sub.add_parser('queue')
+    queue_sub = queue.add_subparsers(dest='queue_cmd')
+
+    qp = queue_sub.add_parser('post')
+    qp.add_argument('thread_id')
+    qp.add_argument('--body')
+    qp.set_defaults(func=cmd_queue_post)
+
+    outbox = sub.add_parser('outbox')
+    outbox_sub = outbox.add_subparsers(dest='outbox_cmd')
+
+    ov = outbox_sub.add_parser('view')
+    ov.set_defaults(func=cmd_outbox_view)
+
+    args = parser.parse_args()
+    if hasattr(args, 'func'):
+        args.func(args)
+    else:
+        parser.print_help()
+
+
+if __name__ == '__main__':
+    main()

--- a/db.py
+++ b/db.py
@@ -1,0 +1,40 @@
+import sqlite3
+from pathlib import Path
+
+DB_PATH = Path('openbbs.db')
+
+def connect(db_path=DB_PATH):
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+def init_db(db_path=DB_PATH):
+    conn = connect(db_path)
+    cur = conn.cursor()
+    cur.execute(
+        """CREATE TABLE IF NOT EXISTS threads (
+            id TEXT PRIMARY KEY,
+            title TEXT,
+            created_at TEXT,
+            updated_at TEXT
+        )"""
+    )
+    cur.execute(
+        """CREATE TABLE IF NOT EXISTS messages (
+            id TEXT PRIMARY KEY,
+            thread_id TEXT,
+            timestamp TEXT,
+            author TEXT,
+            body TEXT
+        )"""
+    )
+    cur.execute(
+        """CREATE TABLE IF NOT EXISTS outbox (
+            id TEXT PRIMARY KEY,
+            thread_id TEXT,
+            body TEXT,
+            queued_at TEXT
+        )"""
+    )
+    conn.commit()
+    conn.close()

--- a/openbbs/__init__.py
+++ b/openbbs/__init__.py
@@ -3,6 +3,8 @@ from flask_sqlalchemy import SQLAlchemy
 from flask_login import LoginManager
 from pathlib import Path
 
+from ..db import init_db
+
 # Database instance
 DB_NAME = 'openbbs.db'
 db = SQLAlchemy()
@@ -25,6 +27,7 @@ def create_app():
     with app.app_context():
         Path(app.config['UPLOAD_FOLDER']).mkdir(exist_ok=True)
         db.create_all()
+        init_db(DB_NAME)
 
     from .auth import auth_bp
     from .views import main_bp
@@ -32,5 +35,7 @@ def create_app():
     app.register_blueprint(auth_bp)
     app.register_blueprint(main_bp)
     app.register_blueprint(forums_bp)
+    from .sync_api import sync_bp
+    app.register_blueprint(sync_bp)
 
     return app

--- a/openbbs/sync_api.py
+++ b/openbbs/sync_api.py
@@ -1,0 +1,46 @@
+import json
+import tempfile
+from flask import Blueprint, request, send_file, jsonify
+from pathlib import Path
+from . import db as sqldb  # SQLAlchemy instance not used but required for models
+from ..sync import SyncEngine
+from ..db import init_db
+
+sync_bp = Blueprint('sync_api', __name__, url_prefix='/api/sync')
+
+def get_engine():
+    db_path = Path('openbbs.db')
+    init_db(db_path)
+    return SyncEngine(str(db_path))
+
+@sync_bp.route('/pull', methods=['POST'])
+def pull_route():
+    data = request.get_json(force=True, silent=True) or {}
+    since = data.get('since')
+    threads = data.get('threads')
+    with tempfile.NamedTemporaryFile(suffix='.tar.zst', delete=False) as tmp:
+        path = tmp.name
+    engine = get_engine()
+    engine.pull(since=since, thread_ids=threads, output_path=path)
+    return send_file(path, as_attachment=True, download_name='sync.tar.zst')
+
+@sync_bp.route('/push', methods=['POST'])
+def push_route():
+    file = request.files.get('file')
+    if file:
+        tmp = tempfile.NamedTemporaryFile(delete=False)
+        file.save(tmp)
+        tmp.close()
+        engine = get_engine()
+        summary = engine.push(tmp.name)
+        Path(tmp.name).unlink(missing_ok=True)
+        return jsonify(summary)
+    if request.data:
+        tmp = tempfile.NamedTemporaryFile(delete=False)
+        tmp.write(request.data)
+        tmp.close()
+        engine = get_engine()
+        summary = engine.push(tmp.name)
+        Path(tmp.name).unlink(missing_ok=True)
+        return jsonify(summary)
+    return jsonify({'error': 'no file provided'}), 400

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ flask
 flask_sqlalchemy
 flask_login
 werkzeug
+zstandard

--- a/sync.py
+++ b/sync.py
@@ -1,0 +1,123 @@
+import json
+import logging
+import sqlite3
+import tarfile
+import tempfile
+from pathlib import Path
+from datetime import datetime
+import zstandard as zstd
+
+from db import connect, init_db
+
+logger = logging.getLogger('sync')
+logger.setLevel(logging.INFO)
+
+if not logger.handlers:
+    fh = logging.FileHandler('sync.log')
+    fh.setLevel(logging.INFO)
+    formatter = logging.Formatter('%(asctime)s %(levelname)s: %(message)s')
+    fh.setFormatter(formatter)
+    logger.addHandler(fh)
+    ch = logging.StreamHandler()
+    ch.setLevel(logging.INFO)
+    logger.addHandler(ch)
+
+class SyncEngine:
+    def __init__(self, db_path='openbbs.db'):
+        self.db_path = db_path
+        init_db(db_path)
+
+    def _conn(self):
+        conn = sqlite3.connect(self.db_path)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def pull(self, since=None, thread_ids=None, output_path='sync.tar.zst'):
+        logger.info('Starting pull operation')
+        conn = self._conn()
+        cur = conn.cursor()
+        params = []
+        query = "SELECT * FROM threads"
+        conditions = []
+        if since:
+            conditions.append("updated_at >= ?")
+            params.append(since)
+        if thread_ids:
+            placeholders = ','.join('?' for _ in thread_ids)
+            conditions.append(f"id IN ({placeholders})")
+            params.extend(thread_ids)
+        if conditions:
+            query += " WHERE " + " AND ".join(conditions)
+        threads = cur.execute(query, params).fetchall()
+        base = Path(tempfile.mkdtemp())
+        (base / 'threads').mkdir()
+        index = []
+        for t in threads:
+            index.append({
+                'id': t['id'],
+                'title': t['title'],
+                'created_at': t['created_at'],
+                'updated_at': t['updated_at'],
+            })
+            msgs = cur.execute(
+                "SELECT * FROM messages WHERE thread_id=?" + (" AND timestamp>=?" if since else ""),
+                [t['id']] + ([since] if since else [])
+            ).fetchall()
+            msgs_data = [dict(m) for m in msgs]
+            with open(base / 'threads' / f"{t['id']}.json", 'w') as f:
+                json.dump(msgs_data, f)
+        with open(base / 'index.json', 'w') as f:
+            json.dump(index, f)
+        tar_path = base / 'package.tar'
+        with tarfile.open(tar_path, 'w') as tar:
+            tar.add(base / 'index.json', arcname='index.json')
+            tar.add(base / 'threads', arcname='threads')
+        compressor = zstd.ZstdCompressor()
+        with open(tar_path, 'rb') as f_in, open(output_path, 'wb') as f_out:
+            f_out.write(compressor.compress(f_in.read()))
+        logger.info('Pull completed: %s', output_path)
+        return output_path
+
+    def push(self, package_path):
+        logger.info('Starting push operation')
+        base = Path(tempfile.mkdtemp())
+        tar_path = base / 'package.tar'
+        decompressor = zstd.ZstdDecompressor()
+        with open(package_path, 'rb') as f_in, open(tar_path, 'wb') as f_out:
+            f_out.write(decompressor.decompress(f_in.read()))
+        with tarfile.open(tar_path, 'r') as tar:
+            tar.extractall(base)
+        with open(base / 'index.json') as f:
+            index = json.load(f)
+        conn = self._conn()
+        cur = conn.cursor()
+        imported_threads = 0
+        imported_msgs = 0
+        for t in index:
+            try:
+                cur.execute(
+                    "INSERT OR IGNORE INTO threads (id, title, created_at, updated_at) VALUES (?,?,?,?)",
+                    (t['id'], t['title'], t['created_at'], t['updated_at'])
+                )
+                if cur.rowcount:
+                    imported_threads += 1
+            except sqlite3.IntegrityError:
+                pass
+            msgs_path = base / 'threads' / f"{t['id']}.json"
+            if msgs_path.exists():
+                with open(msgs_path) as mf:
+                    msgs = json.load(mf)
+                for m in msgs:
+                    try:
+                        cur.execute(
+                            "INSERT OR IGNORE INTO messages (id, thread_id, timestamp, author, body) VALUES (?,?,?,?,?)",
+                            (m['id'], m['thread_id'], m['timestamp'], m.get('author'), m['body'])
+                        )
+                        if cur.rowcount:
+                            imported_msgs += 1
+                    except sqlite3.IntegrityError:
+                        continue
+        conn.commit()
+        conn.close()
+        logger.info('Push completed: %d threads, %d messages', imported_threads, imported_msgs)
+        return {'threads': imported_threads, 'messages': imported_msgs}

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,0 +1,52 @@
+import os
+import tempfile
+from pathlib import Path
+
+from db import init_db, connect
+from sync import SyncEngine
+import bbs
+from bbs import cmd_queue_post, cmd_outbox_view
+
+
+def setup_db():
+    db_fd, db_path = tempfile.mkstemp()
+    os.close(db_fd)
+    init_db(db_path)
+    return db_path
+
+
+def test_pull_push_cycle():
+    db_path = setup_db()
+    conn = connect(db_path)
+    cur = conn.cursor()
+    cur.execute("INSERT INTO threads (id, title, created_at, updated_at) VALUES (?,?,?,?)",
+                ('t1', 'Thread', '2023-01-01T00:00:00', '2023-01-01T00:00:00'))
+    cur.execute("INSERT INTO messages (id, thread_id, timestamp, author, body) VALUES (?,?,?,?,?)",
+                ('m1', 't1', '2023-01-01T00:00:00', 'alice', 'hello'))
+    conn.commit()
+    engine = SyncEngine(db_path)
+    pkg = tempfile.NamedTemporaryFile(suffix='.tar.zst', delete=False).name
+    engine.pull(output_path=pkg)
+    cur.execute('DELETE FROM messages')
+    cur.execute('DELETE FROM threads')
+    conn.commit()
+    summary = engine.push(pkg)
+    cur2 = conn.cursor()
+    t = cur2.execute('SELECT * FROM threads').fetchone()
+    m = cur2.execute('SELECT * FROM messages').fetchone()
+    assert t['id'] == 't1'
+    assert m['id'] == 'm1'
+    assert summary['threads'] == 1
+    assert summary['messages'] == 1
+    Path(pkg).unlink()
+
+
+def test_outbox_queue_and_view(capsys):
+    db_path = setup_db()
+    bbs.DB_PATH = Path(db_path)
+    args = type('obj', (object,), {'thread_id': 't1', 'body': 'message body'})
+    cmd_queue_post(args)
+    view_args = type('obj', (object,), {})
+    cmd_outbox_view(view_args)
+    captured = capsys.readouterr()
+    assert 'message body' in captured.out


### PR DESCRIPTION
## Summary
- create `db.py` with SQLite init for threads, messages, and outbox tables
- implement `SyncEngine` in new `sync.py` with pull and push operations using zstd
- add CLI entry `bbs.py` for sync pull/push, queue post, and outbox view
- add server API routes `/api/sync/pull` and `/api/sync/push`
- ensure DB initialisation and blueprint registration in Flask app
- add unit tests covering sync and queue features
- require `zstandard` dependency

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687e8108ca80832aa253f04fc00fc824