### PR TITLE
Add REST API and sync engine enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 *.pyc
 uploads/*
 !uploads/.gitkeep
+sync.log

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ A simple Bulletin Board System implemented in Python using Flask. It provides us
 - Synchronization API and CLI tools
 - Search functionality for posts
 - Basic COM/VARAHF radio interface (experimental)
+- REST API for threads/messages and lightweight offline UI
+- Local SQLite storage with sync log
 
 ## Setup
 
@@ -29,6 +31,18 @@ python run.py
 ```
 
 Then open `http://localhost:5000` in your browser.
+
+### CLI usage
+
+The `bbs.py` script provides basic commands:
+
+```bash
+python bbs.py list            # list threads
+python bbs.py new "Title"     # create thread
+python bbs.py post <thread> "message" --author bob
+python bbs.py sync pull --since 2023-01-01T00:00:00
+python bbs.py sync push package.tar.zst
+```
 
 ## Notes
 

--- a/db/__init__.py
+++ b/db/__init__.py
@@ -1,5 +1,6 @@
 import sqlite3
 from pathlib import Path
+from datetime import datetime
 
 DB_PATH = Path('openbbs.db')
 
@@ -11,6 +12,7 @@ def connect(db_path=DB_PATH):
 def init_db(db_path=DB_PATH):
     conn = connect(db_path)
     cur = conn.cursor()
+    # basic threads table
     cur.execute(
         """CREATE TABLE IF NOT EXISTS threads (
             id TEXT PRIMARY KEY,
@@ -19,15 +21,18 @@ def init_db(db_path=DB_PATH):
             updated_at TEXT
         )"""
     )
+    # messages now carry an updated_at field for merge logic
     cur.execute(
         """CREATE TABLE IF NOT EXISTS messages (
             id TEXT PRIMARY KEY,
             thread_id TEXT,
             timestamp TEXT,
+            updated_at TEXT,
             author TEXT,
             body TEXT
         )"""
     )
+    # client outbox queue
     cur.execute(
         """CREATE TABLE IF NOT EXISTS outbox (
             id TEXT PRIMARY KEY,
@@ -35,6 +40,26 @@ def init_db(db_path=DB_PATH):
             body TEXT,
             queued_at TEXT
         )"""
+    )
+    # sync log for auditing operations
+    cur.execute(
+        """CREATE TABLE IF NOT EXISTS sync_log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            op TEXT,
+            timestamp TEXT,
+            details TEXT
+        )"""
+    )
+    conn.commit()
+    conn.close()
+
+
+def record_sync(db_path, op, details=""):
+    """Insert a sync operation record."""
+    conn = connect(db_path)
+    conn.execute(
+        "INSERT INTO sync_log (op, timestamp, details) VALUES (?,?,?)",
+        (op, datetime.utcnow().isoformat(), details),
     )
     conn.commit()
     conn.close()

--- a/openbbs/__init__.py
+++ b/openbbs/__init__.py
@@ -37,5 +37,7 @@ def create_app():
     app.register_blueprint(forums_bp)
     from .sync_api import sync_bp
     app.register_blueprint(sync_bp)
+    from .api import api_bp
+    app.register_blueprint(api_bp)
 
     return app

--- a/openbbs/api.py
+++ b/openbbs/api.py
@@ -1,0 +1,64 @@
+from flask import Blueprint, request, jsonify
+from pathlib import Path
+from db import connect, init_db
+import uuid
+from datetime import datetime
+
+api_bp = Blueprint('api', __name__, url_prefix='/api')
+DB_PATH = Path('openbbs.db')
+
+
+def get_conn():
+    init_db(DB_PATH)
+    conn = connect(DB_PATH)
+    return conn
+
+@api_bp.route('/threads', methods=['GET', 'POST'])
+def threads():
+    conn = get_conn()
+    cur = conn.cursor()
+    if request.method == 'POST':
+        data = request.get_json(force=True)
+        tid = data.get('id') or str(uuid.uuid4())
+        now = datetime.utcnow().isoformat()
+        cur.execute(
+            "INSERT INTO threads (id, title, created_at, updated_at) VALUES (?,?,?,?)",
+            (tid, data['title'], now, now),
+        )
+        conn.commit()
+        conn.close()
+        return jsonify({'id': tid})
+    rows = cur.execute("SELECT id, title, updated_at FROM threads ORDER BY updated_at DESC").fetchall()
+    conn.close()
+    return jsonify([dict(r) for r in rows])
+
+@api_bp.route('/threads/<tid>', methods=['GET'])
+def thread_detail(tid):
+    conn = get_conn()
+    cur = conn.cursor()
+    thread = cur.execute("SELECT id, title, updated_at FROM threads WHERE id=?", (tid,)).fetchone()
+    if not thread:
+        conn.close()
+        return jsonify({'error': 'not found'}), 404
+    msgs = cur.execute("SELECT * FROM messages WHERE thread_id=? ORDER BY timestamp", (tid,)).fetchall()
+    conn.close()
+    return jsonify({'thread': dict(thread), 'messages': [dict(m) for m in msgs]})
+
+@api_bp.route('/threads/<tid>/messages', methods=['POST'])
+def post_message(tid):
+    conn = get_conn()
+    cur = conn.cursor()
+    data = request.get_json(force=True)
+    mid = data.get('id') or str(uuid.uuid4())
+    now = datetime.utcnow().isoformat()
+    cur.execute(
+        "INSERT INTO messages (id, thread_id, timestamp, updated_at, author, body) VALUES (?,?,?,?,?,?)",
+        (mid, tid, now, now, data.get('author'), data.get('body', '')),
+    )
+    cur.execute(
+        "UPDATE threads SET updated_at=? WHERE id=?",
+        (now, tid),
+    )
+    conn.commit()
+    conn.close()
+    return jsonify({'id': mid})

--- a/openbbs/templates/offline.html
+++ b/openbbs/templates/offline.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Offline BBS</title>
+  <script>
+  async function loadThreads() {
+    const res = await fetch('/api/threads');
+    const threads = await res.json();
+    const list = document.getElementById('threads');
+    list.innerHTML = '';
+    threads.forEach(t => {
+      const li = document.createElement('li');
+      li.textContent = t.title;
+      li.onclick = () => loadThread(t.id);
+      list.appendChild(li);
+    });
+  }
+  async function loadThread(id) {
+    const res = await fetch('/api/threads/' + id);
+    const data = await res.json();
+    const msgs = document.getElementById('messages');
+    msgs.innerHTML = data.messages.map(m => `<p><b>${m.author||'anon'}</b>: ${m.body}</p>`).join('');
+    document.getElementById('reply').dataset.thread=id;
+  }
+  async function send() {
+    const tid = document.getElementById('reply').dataset.thread;
+    const body = document.getElementById('body').value;
+    await fetch(`/api/threads/${tid}/messages`,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({body})});
+    document.getElementById('body').value='';
+    loadThread(tid);
+  }
+  window.onload = loadThreads;
+  </script>
+</head>
+<body>
+<h1>Offline BBS</h1>
+<ul id="threads"></ul>
+<div id="messages"></div>
+<div>
+  <textarea id="body" rows="4" cols="40"></textarea>
+  <button id="reply" onclick="send()">Send</button>
+</div>
+</body>
+</html>

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -21,8 +21,8 @@ def test_pull_push_cycle():
     cur = conn.cursor()
     cur.execute("INSERT INTO threads (id, title, created_at, updated_at) VALUES (?,?,?,?)",
                 ('t1', 'Thread', '2023-01-01T00:00:00', '2023-01-01T00:00:00'))
-    cur.execute("INSERT INTO messages (id, thread_id, timestamp, author, body) VALUES (?,?,?,?,?)",
-                ('m1', 't1', '2023-01-01T00:00:00', 'alice', 'hello'))
+    cur.execute("INSERT INTO messages (id, thread_id, timestamp, updated_at, author, body) VALUES (?,?,?,?,?,?)",
+                ('m1', 't1', '2023-01-01T00:00:00', '2023-01-01T00:00:00', 'alice', 'hello'))
     conn.commit()
     engine = SyncEngine(db_path)
     pkg = tempfile.NamedTemporaryFile(suffix='.tar.zst', delete=False).name
@@ -44,6 +44,7 @@ def test_pull_push_cycle():
 def test_outbox_queue_and_view(capsys):
     db_path = setup_db()
     bbs.DB_PATH = Path(db_path)
+    bbs.CONF['db_path'] = db_path
     args = type('obj', (object,), {'thread_id': 't1', 'body': 'message body'})
     cmd_queue_post(args)
     view_args = type('obj', (object,), {})


### PR DESCRIPTION
## Summary
- add REST API blueprint for thread and message CRUD
- log sync operations and create `sync_log` table
- enhance sync engine with timestamp merging and updated_at filtering
- extend CLI with thread management commands and config support
- provide simple offline HTML interface
- update tests for new schema

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687eb5b9f4bc832aaed34d616ab48086