### PR TITLE
Add HF radio utilities and error correction

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ flask_login
 werkzeug
 zstandard
 pyserial
+reedsolo
+crcmod

--- a/tests/test_radio_utils.py
+++ b/tests/test_radio_utils.py
@@ -1,0 +1,21 @@
+from radio import fec_encode, fec_decode, add_crc, verify_crc, interleave, deinterleave
+
+
+def test_fec_round_trip():
+    data = b"hello world"
+    encoded = fec_encode(data)
+    decoded = fec_decode(encoded)
+    assert decoded == data
+
+
+def test_crc_round_trip():
+    data = b"abc123"
+    framed = add_crc(data)
+    assert verify_crc(framed) == data
+
+
+def test_interleave_round_trip():
+    data = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    inter = interleave(data, 4)
+    deinter = deinterleave(inter, 4)
+    assert deinter == data


### PR DESCRIPTION
## Summary
- expand `radio` with baud negotiation, heartbeat, error correction helpers, CRC and interleaving
- add sliding-window ARQ helper
- update requirements with new dependencies
- test new radio utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687ec592db80832a83ca68e417603f99