### PR TITLE
Implement scheduler stubs and Merkle utilities

### DIFF
--- a/merkle.py
+++ b/merkle.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+from hashlib import sha256
+from typing import Iterable, List
+
+
+def merkle_root(leaves: Iterable[bytes]) -> bytes:
+    """Return the Merkle root of *leaves* using SHA-256."""
+    nodes = [sha256(l).digest() for l in leaves]
+    if not nodes:
+        return b"\x00" * 32
+    while len(nodes) > 1:
+        if len(nodes) % 2 == 1:
+            nodes.append(nodes[-1])
+        nodes = [sha256(nodes[i] + nodes[i + 1]).digest() for i in range(0, len(nodes), 2)]
+    return nodes[0]
+
+
+def diff_indices(local: List[bytes], remote_root: bytes) -> List[int]:
+    """Return indices of leaves that differ from *remote_root*.
+    This is a naive implementation for small trees.
+    """
+    mismatched = []
+    for idx, leaf in enumerate(local):
+        if merkle_root([leaf]) != remote_root:
+            mismatched.append(idx)
+    return mismatched

--- a/scheduler.py
+++ b/scheduler.py
@@ -1,0 +1,63 @@
+# Simple scheduler and priority queue for radio sync operations
+from __future__ import annotations
+import heapq
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, List, Optional
+
+@dataclass(order=True)
+class PrioritizedItem:
+    priority: int
+    item: Any=field(compare=False)
+    attempts: int=field(default=0, compare=False)
+    next_attempt: float=field(default_factory=lambda: time.time(), compare=False)
+
+class PrioritySyncQueue:
+    """In-memory priority queue with retry/backoff metadata."""
+    def __init__(self):
+        self._heap: List[PrioritizedItem] = []
+
+    def push(self, item: Any, priority: int = 10) -> None:
+        heapq.heappush(self._heap, PrioritizedItem(priority, item))
+
+    def pop(self) -> Optional[PrioritizedItem]:
+        if not self._heap:
+            return None
+        top = self._heap[0]
+        if top.next_attempt <= time.time():
+            return heapq.heappop(self._heap)
+        return None
+
+    def __len__(self) -> int:
+        return len(self._heap)
+
+class LinkScheduler:
+    """Schedule periodic sync jobs respecting duty-cycle limits."""
+    def __init__(self, send_fn: Callable[[bytes], None], window: float = 60.0):
+        self.send_fn = send_fn
+        self.window = window
+        self.queue = PrioritySyncQueue()
+        self._last_tx = 0.0
+
+    def queue_packet(self, packet: bytes, priority: int = 10) -> None:
+        self.queue.push(packet, priority)
+
+    def run_once(self) -> None:
+        if not len(self.queue):
+            return
+        item = self.queue.pop()
+        if not item:
+            return
+        if time.time() - self._last_tx < self.window:
+            # not within allowed window yet
+            item.next_attempt = time.time() + self.window
+            self.queue.push(item.item, item.priority)
+            return
+        try:
+            self.send_fn(item.item)
+            self._last_tx = time.time()
+        except Exception:
+            item.attempts += 1
+            # simple exponential backoff
+            item.next_attempt = time.time() + min(60 * (2 ** item.attempts), 3600)
+            self.queue.push(item.item, item.priority)


### PR DESCRIPTION
## Summary
- add a simple adaptive `LinkScheduler` and `PrioritySyncQueue`
- implement basic `merkle_root` utility with diff helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687ec7744f88832a86e7de7eac534a34