### PR TITLE
Add key cache and duty cycle awareness

### DIFF
--- a/keycache.py
+++ b/keycache.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+import json
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Optional
+
+@dataclass
+class KeyEntry:
+    fingerprint: str
+    version: int
+    key_data: str
+
+class VersionedKeyCache:
+    """Simple on-disk cache of keys identified by fingerprint and version."""
+    def __init__(self, path: str = 'keycache.json'):
+        self.path = Path(path)
+        self._cache: dict[str, KeyEntry] = {}
+        self._load()
+
+    def _load(self) -> None:
+        if self.path.exists():
+            with open(self.path) as f:
+                data = json.load(f)
+            for fp, entry in data.items():
+                self._cache[fp] = KeyEntry(**entry)
+
+    def _save(self) -> None:
+        with open(self.path, 'w') as f:
+            json.dump({fp: asdict(e) for fp, e in self._cache.items()}, f)
+
+    def get(self, fingerprint: str) -> Optional[tuple[int, str]]:
+        entry = self._cache.get(fingerprint)
+        if entry:
+            return entry.version, entry.key_data
+        return None
+
+    def update(self, fingerprint: str, version: int, key_data: str) -> bool:
+        entry = self._cache.get(fingerprint)
+        if entry and entry.version >= version:
+            return False
+        self._cache[fingerprint] = KeyEntry(fingerprint, version, key_data)
+        self._save()
+        return True

--- a/merkle.py
+++ b/merkle.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+from hashlib import sha256
+from typing import Iterable, List
+
+
+def merkle_root(leaves: Iterable[bytes]) -> bytes:
+    """Return the Merkle root of *leaves* using SHA-256."""
+    nodes = [sha256(l).digest() for l in leaves]
+    if not nodes:
+        return b"\x00" * 32
+    while len(nodes) > 1:
+        if len(nodes) % 2 == 1:
+            nodes.append(nodes[-1])
+        nodes = [sha256(nodes[i] + nodes[i + 1]).digest() for i in range(0, len(nodes), 2)]
+    return nodes[0]
+
+
+def diff_indices(local: List[bytes], remote_root: bytes) -> List[int]:
+    """Return indices of leaves that differ from *remote_root*.
+    This is a naive implementation for small trees.
+    """
+    mismatched = []
+    for idx, leaf in enumerate(local):
+        if merkle_root([leaf]) != remote_root:
+            mismatched.append(idx)
+    return mismatched

--- a/radio.py
+++ b/radio.py
@@ -39,6 +39,15 @@ class RadioInterface:
             self.open()
         return self.ser.read(size)
 
+    def is_busy(self) -> bool:
+        """Return ``True`` if carrier detect is asserted."""
+        if not self.ser:
+            self.open()
+        try:
+            return bool(getattr(self.ser, "cd", False))
+        except Exception:
+            return False
+
     def negotiate_baud(self, rates: Iterable[int] = (57600, 38400, 19200, 9600)) -> int:
         """Attempt to open the serial port at the fastest working baud rate."""
         for rate in rates:

--- a/scheduler.py
+++ b/scheduler.py
@@ -1,0 +1,70 @@
+# Simple scheduler and priority queue for radio sync operations
+from __future__ import annotations
+import heapq
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, List, Optional
+
+@dataclass(order=True)
+class PrioritizedItem:
+    priority: int
+    item: Any=field(compare=False)
+    attempts: int=field(default=0, compare=False)
+    next_attempt: float=field(default_factory=lambda: time.time(), compare=False)
+
+class PrioritySyncQueue:
+    """In-memory priority queue with retry/backoff metadata."""
+    def __init__(self):
+        self._heap: List[PrioritizedItem] = []
+
+    def push(self, item: Any, priority: int = 10) -> None:
+        heapq.heappush(self._heap, PrioritizedItem(priority, item))
+
+    def pop(self) -> Optional[PrioritizedItem]:
+        if not self._heap:
+            return None
+        top = self._heap[0]
+        if top.next_attempt <= time.time():
+            return heapq.heappop(self._heap)
+        return None
+
+    def __len__(self) -> int:
+        return len(self._heap)
+
+class LinkScheduler:
+    """Schedule periodic sync jobs respecting duty-cycle limits."""
+
+    def __init__(self, send_fn: Callable[[bytes], None], window: float = 60.0,
+                 busy_check: Optional[Callable[[], bool]] = None):
+        self.send_fn = send_fn
+        self.window = window
+        self.busy_check = busy_check
+        self.queue = PrioritySyncQueue()
+        self._last_tx = 0.0
+
+    def queue_packet(self, packet: bytes, priority: int = 10) -> None:
+        self.queue.push(packet, priority)
+
+    def run_once(self) -> None:
+        if not len(self.queue):
+            return
+        item = self.queue.pop()
+        if not item:
+            return
+        if self.busy_check and self.busy_check():
+            item.next_attempt = time.time() + self.window
+            self.queue.push(item.item, item.priority)
+            return
+        if time.time() - self._last_tx < self.window:
+            # not within allowed window yet
+            item.next_attempt = time.time() + self.window
+            self.queue.push(item.item, item.priority)
+            return
+        try:
+            self.send_fn(item.item)
+            self._last_tx = time.time()
+        except Exception:
+            item.attempts += 1
+            # simple exponential backoff
+            item.next_attempt = time.time() + min(60 * (2 ** item.attempts), 3600)
+            self.queue.push(item.item, item.priority)

--- a/tests/test_keycache.py
+++ b/tests/test_keycache.py
@@ -1,0 +1,14 @@
+from keycache import VersionedKeyCache
+
+
+def test_keycache_update_and_get(tmp_path):
+    path = tmp_path / "kc.json"
+    kc = VersionedKeyCache(str(path))
+    assert kc.update("abc", 1, "KEYDATA")
+    assert kc.get("abc") == (1, "KEYDATA")
+    # lower version should not replace
+    assert not kc.update("abc", 1, "NEW")
+    assert kc.get("abc") == (1, "KEYDATA")
+    # higher version replaces
+    assert kc.update("abc", 2, "NEW")
+    assert kc.get("abc") == (2, "NEW")

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,20 @@
+from scheduler import LinkScheduler
+
+
+def test_scheduler_busy_check():
+    sent = []
+    busy = True
+
+    def send_fn(data):
+        sent.append(data)
+
+    def check():
+        return busy
+
+    sched = LinkScheduler(send_fn, window=0, busy_check=check)
+    sched.queue_packet(b"hi", priority=5)
+    sched.run_once()
+    assert not sent
+    busy = False
+    sched.run_once()
+    assert sent == [b"hi"]


### PR DESCRIPTION
## Summary
- support serial carrier detect with `RadioInterface.is_busy`
- extend `LinkScheduler` to respect a busy callback
- implement a simple `VersionedKeyCache`
- test key cache and scheduler busy logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687ec7744f88832a86e7de7eac534a34