### PR TITLE
Add post editing and moderation

### DIFF
--- a/openbbs/forums.py
+++ b/openbbs/forums.py
@@ -38,4 +38,4 @@ def view_forum(forum_id):
 
 @lru_cache(maxsize=128)
 def get_forum_posts(forum_id):
-    return Post.query.filter_by(forum_id=forum_id, parent_id=None).order_by(Post.timestamp.desc()).all()
+    return Post.query.filter_by(forum_id=forum_id, parent_id=None, deleted=False).order_by(Post.timestamp.desc()).all()

--- a/openbbs/models.py
+++ b/openbbs/models.py
@@ -9,6 +9,7 @@ class User(db.Model, UserMixin):
     password = db.Column(db.String(150), nullable=False)
     bio = db.Column(db.Text, default="")
     reputation = db.Column(db.Integer, default=0)
+    is_moderator = db.Column(db.Boolean, default=False)
     posts = db.relationship('Post', backref='author', lazy=True)
 
 
@@ -24,6 +25,8 @@ class Post(db.Model):
     title = db.Column(db.String(255), nullable=False)
     body = db.Column(db.Text, nullable=False)
     timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+    edited_at = db.Column(db.DateTime)
+    deleted = db.Column(db.Boolean, default=False)
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
     forum_id = db.Column(db.Integer, db.ForeignKey('forum.id'), nullable=False)
     parent_id = db.Column(db.Integer, db.ForeignKey('post.id'))

--- a/openbbs/templates/edit_post.html
+++ b/openbbs/templates/edit_post.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Edit Post</h2>
+<form method="post">
+  <div class="mb-3">
+    <input class="form-control" type="text" name="title" value="{{ post.title }}" required>
+  </div>
+  <div class="mb-3">
+    <textarea class="form-control" name="body" rows="4" required>{{ post.body }}</textarea>
+  </div>
+  <button class="btn btn-success" type="submit">Save</button>
+  <a href="{{ url_for('forums.view_forum', forum_id=post.forum_id) }}" class="btn btn-secondary">Cancel</a>
+</form>
+{% endblock %}
+

--- a/openbbs/templates/forum_view.html
+++ b/openbbs/templates/forum_view.html
@@ -20,17 +20,39 @@
   {% for post in posts %}
   <li class="list-group-item">
     <h5>{{ post.title }} <small class="text-muted">by {{ post.author.username }} at {{ post.timestamp.strftime('%Y-%m-%d %H:%M') }}</small></h5>
+    {% if post.edited_at %}
+    <p class="small text-muted">edited {{ post.edited_at.strftime('%Y-%m-%d %H:%M') }}</p>
+    {% endif %}
     <p>{{ post.body }}</p>
+    {% if current_user.is_authenticated and (current_user.is_moderator or current_user.id == post.user_id) %}
+    <div class="mb-2">
+      <a href="{{ url_for('main.edit_post', post_id=post.id) }}" class="btn btn-sm btn-outline-primary">Edit</a>
+      <form method="post" action="{{ url_for('main.delete_post', post_id=post.id) }}" class="d-inline">
+        <button class="btn btn-sm btn-outline-danger" type="submit">Delete</button>
+      </form>
+    </div>
+    {% endif %}
     {% for att in post.attachments %}
     <p><a href="{{ url_for('main.get_attachment', att_id=att.id) }}">{{ att.original_name }}</a></p>
     {% endfor %}
-    {% for reply in post.children %}
+    {% for reply in post.children if not reply.deleted %}
     <div class="mt-3 ms-3 border-start ps-3">
       <h6>{{ reply.title }} <small class="text-muted">by {{ reply.author.username }} at {{ reply.timestamp.strftime('%Y-%m-%d %H:%M') }}</small></h6>
+      {% if reply.edited_at %}
+      <p class="small text-muted">edited {{ reply.edited_at.strftime('%Y-%m-%d %H:%M') }}</p>
+      {% endif %}
       <p>{{ reply.body }}</p>
       {% for ratt in reply.attachments %}
       <p><a href="{{ url_for('main.get_attachment', att_id=ratt.id) }}">{{ ratt.original_name }}</a></p>
       {% endfor %}
+      {% if current_user.is_authenticated and (current_user.is_moderator or current_user.id == reply.user_id) %}
+      <div class="mb-2">
+        <a href="{{ url_for('main.edit_post', post_id=reply.id) }}" class="btn btn-sm btn-outline-primary">Edit</a>
+        <form method="post" action="{{ url_for('main.delete_post', post_id=reply.id) }}" class="d-inline">
+          <button class="btn btn-sm btn-outline-danger" type="submit">Delete</button>
+        </form>
+      </div>
+      {% endif %}
     </div>
     {% endfor %}
     <form method="post" action="{{ url_for('main.create_post') }}" enctype="multipart/form-data" class="mt-3">

--- a/openbbs/templates/search.html
+++ b/openbbs/templates/search.html
@@ -2,16 +2,23 @@
 {% block content %}
 <h2>Search</h2>
 <form method="get" action="{{ url_for('main.search') }}" class="mb-3">
-  <div class="input-group">
-    <input class="form-control" type="text" name="q" placeholder="Search" value="{{ query }}">
-    <button class="btn btn-primary" type="submit">Search</button>
+  <div class="row g-2">
+    <div class="col">
+      <input class="form-control" type="text" name="q" placeholder="Search" value="{{ query }}">
+    </div>
+    <div class="col">
+      <input class="form-control" type="text" name="author" placeholder="Author" value="{{ request.args.get('author', '') }}">
+    </div>
+    <div class="col-auto">
+      <button class="btn btn-primary" type="submit">Search</button>
+    </div>
   </div>
 </form>
 <ul class="list-group">
   {% for post in results %}
   <li class="list-group-item">
     <h5>{{ post.title }} <small class="text-muted">by {{ post.author.username }} at {{ post.timestamp.strftime('%Y-%m-%d %H:%M') }}</small></h5>
-    <p>{{ post.body }}</p>
+    <p>{{ post.body[:150] }}{% if post.body|length > 150 %}...{% endif %}</p>
     <p><a href="{{ url_for('forums.view_forum', forum_id=post.forum_id) }}">View Forum</a></p>
   </li>
   {% else %}

--- a/tests/test_post_edit.py
+++ b/tests/test_post_edit.py
@@ -1,0 +1,74 @@
+from openbbs import create_app, db
+from openbbs.models import User, Forum, Post
+import pytest
+
+@pytest.fixture
+def app_ctx(tmp_path):
+    app = create_app()
+    app.config['SQLALCHEMY_DATABASE_URI'] = f'sqlite:///{tmp_path / "test.db"}'
+    app.config['TESTING'] = True
+    with app.app_context():
+        db.create_all()
+        yield app
+
+@pytest.fixture
+def client(app_ctx):
+    return app_ctx.test_client()
+
+
+def create_user(username, is_mod=False):
+    user = User(username=username, password='pw', is_moderator=is_mod)
+    db.session.add(user)
+    db.session.commit()
+    return user
+
+
+def login(client, username):
+    with client.session_transaction() as sess:
+        sess['_user_id'] = str(User.query.filter_by(username=username).first().id)
+
+
+def test_edit_post_updates_timestamp(app_ctx, client):
+    user = create_user('alice')
+    forum = Forum(name='f1')
+    db.session.add(forum)
+    db.session.commit()
+    post = Post(title='t', body='b', author=user, forum=forum)
+    db.session.add(post)
+    db.session.commit()
+    login(client, 'alice')
+    resp = client.post(f'/post/{post.id}/edit', data={'title': 't2', 'body': 'b2'})
+    assert resp.status_code == 302
+    updated = Post.query.get(post.id)
+    assert updated.title == 't2'
+    assert updated.edited_at is not None
+
+
+def test_soft_delete_for_user(app_ctx, client):
+    user = create_user('bob')
+    forum = Forum(name='f2')
+    db.session.add(forum)
+    db.session.commit()
+    post = Post(title='t', body='b', author=user, forum=forum)
+    db.session.add(post)
+    db.session.commit()
+    login(client, 'bob')
+    resp = client.post(f'/post/{post.id}/delete')
+    assert resp.status_code == 302
+    assert Post.query.get(post.id).deleted
+
+
+def test_hard_delete_for_moderator(app_ctx, client):
+    mod = create_user('mod', is_mod=True)
+    user = create_user('user')
+    forum = Forum(name='f3')
+    db.session.add(forum)
+    db.session.commit()
+    post = Post(title='t', body='b', author=user, forum=forum)
+    db.session.add(post)
+    db.session.commit()
+    login(client, 'mod')
+    resp = client.post(f'/post/{post.id}/delete')
+    assert resp.status_code == 302
+    assert Post.query.get(post.id) is None
+


### PR DESCRIPTION
## Summary
- support moderator role and post editing
- allow soft and hard post deletion
- filter deleted posts from listings and search
- extend search form with author filter and snippet preview
- add tests for edit and delete behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687ee2659a60832ab1cd1d66e2147f3b