### PR TITLE
Secure post actions with signed tokens

### DIFF
--- a/openbbs/__init__.py
+++ b/openbbs/__init__.py
@@ -41,7 +41,7 @@ def create_app():
         init_db(DB_NAME)
 
     from .auth import auth_bp
-    from .views import main_bp
+    from .views import main_bp, generate_action_token
     from .forums import forums_bp
     app.register_blueprint(auth_bp)
     app.register_blueprint(main_bp)
@@ -50,5 +50,16 @@ def create_app():
     app.register_blueprint(sync_bp)
     from .api import api_bp
     app.register_blueprint(api_bp)
+
+    @app.context_processor
+    def inject_action_token():
+        from flask_login import current_user
+
+        def action_token(post_id: int) -> str:
+            if not current_user.is_authenticated:
+                return ""
+            return generate_action_token(post_id, current_user.id)
+
+        return {"action_token": action_token}
 
     return app

--- a/openbbs/templates/edit_post.html
+++ b/openbbs/templates/edit_post.html
@@ -2,6 +2,7 @@
 {% block content %}
 <h2>Edit Post</h2>
 <form method="post">
+  <input type="hidden" name="token" value="{{ token }}">
   <div class="mb-3">
     <input class="form-control" type="text" name="title" value="{{ post.title }}" required>
   </div>

--- a/openbbs/templates/forum_view.html
+++ b/openbbs/templates/forum_view.html
@@ -31,6 +31,7 @@
     <div class="mb-2">
       <a href="{{ url_for('main.edit_post', post_id=post.id) }}" class="btn btn-sm btn-outline-primary">Edit</a>
       <form method="post" action="{{ url_for('main.delete_post', post_id=post.id) }}" class="d-inline">
+        <input type="hidden" name="token" value="{{ action_token(post.id) }}">
         <button class="btn btn-sm btn-outline-danger" type="submit">Delete</button>
       </form>
     </div>
@@ -56,6 +57,7 @@
         <div class="mb-2">
           <a href="{{ url_for('main.edit_post', post_id=reply.id) }}" class="btn btn-sm btn-outline-primary">Edit</a>
           <form method="post" action="{{ url_for('main.delete_post', post_id=reply.id) }}" class="d-inline">
+            <input type="hidden" name="token" value="{{ action_token(reply.id) }}">
             <button class="btn btn-sm btn-outline-danger" type="submit">Delete</button>
           </form>
         </div>

--- a/tests/test_post_edit.py
+++ b/tests/test_post_edit.py
@@ -1,5 +1,6 @@
 from openbbs import create_app, db
 from openbbs.models import User, Forum, Post
+from openbbs.views import generate_action_token
 import pytest
 
 @pytest.fixture
@@ -37,7 +38,8 @@ def test_edit_post_updates_timestamp(app_ctx, client):
     db.session.add(post)
     db.session.commit()
     login(client, 'alice')
-    resp = client.post(f'/post/{post.id}/edit', data={'title': 't2', 'body': 'b2'})
+    token = generate_action_token(post.id, user.id)
+    resp = client.post(f'/post/{post.id}/edit', data={'title': 't2', 'body': 'b2', 'token': token})
     assert resp.status_code == 302
     updated = Post.query.get(post.id)
     assert updated.title == 't2'
@@ -53,7 +55,8 @@ def test_soft_delete_for_user(app_ctx, client):
     db.session.add(post)
     db.session.commit()
     login(client, 'bob')
-    resp = client.post(f'/post/{post.id}/delete')
+    token = generate_action_token(post.id, user.id)
+    resp = client.post(f'/post/{post.id}/delete', data={'token': token})
     assert resp.status_code == 302
     assert Post.query.get(post.id).deleted
 
@@ -68,7 +71,36 @@ def test_hard_delete_for_moderator(app_ctx, client):
     db.session.add(post)
     db.session.commit()
     login(client, 'mod')
-    resp = client.post(f'/post/{post.id}/delete')
+    token = generate_action_token(post.id, mod.id)
+    resp = client.post(f'/post/{post.id}/delete', data={'token': token})
     assert resp.status_code == 302
     assert Post.query.get(post.id) is None
+
+
+def test_invalid_token_prevents_edit(app_ctx, client):
+    user = create_user('carol')
+    forum = Forum(name='f4')
+    db.session.add(forum)
+    db.session.commit()
+    post = Post(title='t', body='b', author=user, forum=forum)
+    db.session.add(post)
+    db.session.commit()
+    login(client, 'carol')
+    resp = client.post(f'/post/{post.id}/edit', data={'title': 'x', 'body': 'y', 'token': 'bad'})
+    assert resp.status_code == 302
+    assert Post.query.get(post.id).title == 't'
+
+
+def test_invalid_token_prevents_delete(app_ctx, client):
+    user = create_user('dave')
+    forum = Forum(name='f5')
+    db.session.add(forum)
+    db.session.commit()
+    post = Post(title='t', body='b', author=user, forum=forum)
+    db.session.add(post)
+    db.session.commit()
+    login(client, 'dave')
+    resp = client.post(f'/post/{post.id}/delete', data={'token': 'bad'})
+    assert resp.status_code == 302
+    assert not Post.query.get(post.id).deleted
 


### PR DESCRIPTION
## Summary
- verify editing and deletion requests using signed tokens
- expose an `action_token` template function
- include token fields in post forms
- test that invalid tokens do not allow modifications

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687ee78c9e78832aa57c568f1aca4593