### PR TITLE
Add moderator trash restoration

### DIFF
--- a/openbbs/templates/base.html
+++ b/openbbs/templates/base.html
@@ -20,6 +20,11 @@
           <a class="nav-link" href="{{ url_for('main.index') }}">Forums</a>
         </li>
         {% if current_user.is_authenticated %}
+        {% if current_user.is_moderator %}
+        <li class="nav-item">
+          <a class="nav-link" href="{{ url_for('main.trash') }}">Trash</a>
+        </li>
+        {% endif %}
         <li class="nav-item">
           <a class="nav-link" href="{{ url_for('main.profile', username=current_user.username) }}">Profile</a>
         </li>

--- a/openbbs/templates/trash.html
+++ b/openbbs/templates/trash.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Deleted Posts</h2>
+<ul class="list-group">
+  {% for post in posts %}
+  <li class="list-group-item">
+    <h5>{{ post.title }} <small class="text-muted">by {{ post.author.username }} at {{ post.timestamp.strftime('%Y-%m-%d %H:%M') }}</small></h5>
+    <form method="post" action="{{ url_for('main.restore_post', post_id=post.id) }}" class="d-inline">
+      <input type="hidden" name="token" value="{{ action_token(post.id) }}">
+      <button class="btn btn-sm btn-success" type="submit">Restore</button>
+    </form>
+  </li>
+  {% else %}
+  <li class="list-group-item">No deleted posts</li>
+  {% endfor %}
+</ul>
+{% endblock %}

--- a/tests/test_post_edit.py
+++ b/tests/test_post_edit.py
@@ -104,3 +104,19 @@ def test_invalid_token_prevents_delete(app_ctx, client):
     assert resp.status_code == 302
     assert not Post.query.get(post.id).deleted
 
+
+def test_restore_post(app_ctx, client):
+    mod = create_user('rest_mod', is_mod=True)
+    user = create_user('frank')
+    forum = Forum(name='f6')
+    db.session.add(forum)
+    db.session.commit()
+    post = Post(title='t', body='b', author=user, forum=forum, deleted=True)
+    db.session.add(post)
+    db.session.commit()
+    login(client, 'rest_mod')
+    token = generate_action_token(post.id, mod.id)
+    resp = client.post(f'/post/{post.id}/restore', data={'token': token})
+    assert resp.status_code == 302
+    assert not Post.query.get(post.id).deleted
+


### PR DESCRIPTION
## Summary
- allow moderators to access a Trash view
- restore deleted posts from Trash
- show Trash link for moderators
- test restoring posts

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687ee8e591e0832a92a737632dbc9699