### PR TITLE
Add thread owner moderator control

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Additional usage information is available in [docs/USAGE.md](docs/USAGE.md).
 - Support for VARA Terminal's KISS serial mode via `VaraKISS`
 - REST API for threads/messages and lightweight offline UI
 - Local SQLite storage with sync log
+- Thread owners can grant moderator status via signed ownership tokens
 
 ## Setup
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -9,6 +9,7 @@ This guide provides an overview of running the server, using the web interface a
 3. Navigate to `http://localhost:5000` in your browser.
 
 On first launch you can sign up for a new account. Forums and posts are stored in a local SQLite database `openbbs.db`.
+Thread owners can promote other users to moderator status by visiting their profile from the thread page.
 
 ## Command Line Interface
 

--- a/openbbs/models.py
+++ b/openbbs/models.py
@@ -29,6 +29,7 @@ class Post(db.Model):
     edited_at = db.Column(db.DateTime)
     deleted = db.Column(db.Boolean, default=False)
     is_pinned = db.Column(db.Boolean, default=False)
+    owner_token = db.Column(db.String(64))
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
     forum_id = db.Column(db.Integer, db.ForeignKey('forum.id'), nullable=False)
     parent_id = db.Column(db.Integer, db.ForeignKey('post.id'))

--- a/openbbs/templates/forum_view.html
+++ b/openbbs/templates/forum_view.html
@@ -23,7 +23,7 @@
     <p class="fst-italic text-muted">This post has been deleted</p>
     {% else %}
     <h5>{{ post.title }} {% if post.is_pinned %}<span class="badge bg-warning text-dark">Pinned</span>{% endif %}
-      <small class="text-muted">by {{ post.author.username }}
+      <small class="text-muted">by <a href="{{ url_for('main.profile', username=post.author.username, thread_id=post.id) }}">{{ post.author.username }}</a>
         {% if post.author.is_moderator %}<span class="badge bg-primary">Mod</span>{% endif %}
         (joined {{ post.author.created_at.strftime('%Y-%m-%d') }})
         [{{ post.author.reputation }}]
@@ -56,7 +56,7 @@
         {% if reply.deleted %}
         <p class="fst-italic text-muted">This post has been deleted</p>
         {% else %}
-        <h6>{{ reply.title }} <small class="text-muted">by {{ reply.author.username }}
+        <h6>{{ reply.title }} <small class="text-muted">by <a href="{{ url_for('main.profile', username=reply.author.username, thread_id=post.id) }}">{{ reply.author.username }}</a>
             {% if reply.author.is_moderator %}<span class="badge bg-primary">Mod</span>{% endif %}
             (joined {{ reply.author.created_at.strftime('%Y-%m-%d') }})
             [{{ reply.author.reputation }}]

--- a/openbbs/templates/profile.html
+++ b/openbbs/templates/profile.html
@@ -3,9 +3,10 @@
 <h2>{{ user.username }}'s Profile {% if user.is_moderator %}<span class="badge bg-primary">Mod</span>{% endif %}</h2>
 <p>{{ user.bio }}</p>
 <p>Joined {{ user.created_at.strftime('%Y-%m-%d') }} | Reputation: {{ user.reputation }}</p>
-{% if current_user.is_authenticated and current_user.is_moderator and current_user.id != user.id %}
+{% if current_user.is_authenticated and current_user.id != user.id and (current_user.is_moderator or owner) %}
 <form method="post" action="{{ url_for('main.toggle_mod', user_id=user.id) }}" class="mb-3">
   <input type="hidden" name="token" value="{{ token }}">
+  {% if thread_id %}<input type="hidden" name="thread_id" value="{{ thread_id }}">{% endif %}
   <button class="btn btn-sm btn-outline-secondary" type="submit">{{ 'Revoke Moderator' if user.is_moderator else 'Make Moderator' }}</button>
 </form>
 {% endif %}

--- a/tests/test_thread_owner_mod.py
+++ b/tests/test_thread_owner_mod.py
@@ -1,0 +1,81 @@
+from openbbs import create_app, db
+from openbbs.models import User, Forum, Post
+from openbbs.views import generate_action_token, verify_owner_token, generate_owner_token
+import pytest
+
+@pytest.fixture
+def app_ctx(tmp_path):
+    app = create_app()
+    app.config['SQLALCHEMY_DATABASE_URI'] = f'sqlite:///{tmp_path / "test.db"}'
+    app.config['TESTING'] = True
+    with app.app_context():
+        db.create_all()
+        yield app
+
+@pytest.fixture
+def client(app_ctx):
+    return app_ctx.test_client()
+
+
+def create_user(username, is_mod=False):
+    user = User(username=username, password='pw', is_moderator=is_mod)
+    db.session.add(user)
+    db.session.commit()
+    return user
+
+
+def login(client, username):
+    with client.session_transaction() as sess:
+        sess['_user_id'] = str(User.query.filter_by(username=username).first().id)
+
+
+def test_thread_owner_token(app_ctx):
+    owner = create_user('owner')
+    forum = Forum(name='f1')
+    db.session.add(forum)
+    db.session.commit()
+    post = Post(title='t', body='b', author=owner, forum=forum)
+    db.session.add(post)
+    db.session.flush()
+    post.owner_token = generate_owner_token(post.id, owner.id)
+    db.session.commit()
+    assert verify_owner_token(post)
+
+
+def test_owner_can_make_mod(app_ctx, client):
+    owner = create_user('alice')
+    other = create_user('bob')
+    forum = Forum(name='f2')
+    db.session.add(forum)
+    db.session.commit()
+    post = Post(title='topic', body='x', author=owner, forum=forum)
+    db.session.add(post)
+    db.session.flush()
+    post.owner_token = generate_owner_token(post.id, owner.id)
+    db.session.commit()
+    assert verify_owner_token(post)
+    login(client, 'alice')
+    token = generate_action_token(other.id, owner.id)
+    resp = client.post(f'/user/{other.id}/toggle_mod', data={'token': token, 'thread_id': post.id})
+    assert resp.status_code == 302
+    assert User.query.get(other.id).is_moderator
+
+
+def test_non_owner_cannot_make_mod(app_ctx, client):
+    owner = create_user('owner2')
+    other = create_user('charlie')
+    outsider = create_user('eve')
+    forum = Forum(name='f3')
+    db.session.add(forum)
+    db.session.commit()
+    post = Post(title='topic2', body='x', author=owner, forum=forum)
+    db.session.add(post)
+    db.session.flush()
+    post.owner_token = generate_owner_token(post.id, owner.id)
+    db.session.commit()
+    login(client, 'eve')
+    token = generate_action_token(other.id, outsider.id)
+    resp = client.post(f'/user/{other.id}/toggle_mod', data={'token': token, 'thread_id': post.id})
+    assert resp.status_code == 302
+    assert not User.query.get(other.id).is_moderator
+


### PR DESCRIPTION
## Summary
- allow post threads to keep a permanent owner token
- let thread owners toggle moderator status via profile page
- expose owner token helpers
- link usernames to profile with thread context
- document new moderator feature
- test new ownership and moderator promotion logic

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687fa9597b7c832a8046506c38dee99f