### PR TITLE
Extend moderation tools

### DIFF
--- a/openbbs/__init__.py
+++ b/openbbs/__init__.py
@@ -34,7 +34,7 @@ def create_app():
     db.init_app(app)
     login_manager.init_app(app)
 
-    from .models import User, Post, Forum, Attachment
+    from .models import User, Post, Forum, Attachment, Flag
 
     with app.app_context():
         Path(app.config['UPLOAD_FOLDER']).mkdir(exist_ok=True)
@@ -46,6 +46,9 @@ def create_app():
             db.session.commit()
         if 'is_pinned' not in [c['name'] for c in insp.get_columns('post')]:
             db.session.execute(text('ALTER TABLE post ADD COLUMN is_pinned BOOLEAN DEFAULT 0'))
+            db.session.commit()
+        if 'is_locked' not in [c['name'] for c in insp.get_columns('post')]:
+            db.session.execute(text('ALTER TABLE post ADD COLUMN is_locked BOOLEAN DEFAULT 0'))
             db.session.commit()
         init_db(DB_NAME)
 

--- a/openbbs/models.py
+++ b/openbbs/models.py
@@ -12,6 +12,7 @@ class User(db.Model, UserMixin):
     is_moderator = db.Column(db.Boolean, default=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     posts = db.relationship('Post', backref='author', lazy=True)
+    flags = db.relationship('Flag', backref='reporter', lazy=True)
 
 
 class Forum(db.Model):
@@ -29,12 +30,14 @@ class Post(db.Model):
     edited_at = db.Column(db.DateTime)
     deleted = db.Column(db.Boolean, default=False)
     is_pinned = db.Column(db.Boolean, default=False)
+    is_locked = db.Column(db.Boolean, default=False)
     owner_token = db.Column(db.String(64))
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
     forum_id = db.Column(db.Integer, db.ForeignKey('forum.id'), nullable=False)
     parent_id = db.Column(db.Integer, db.ForeignKey('post.id'))
     children = db.relationship('Post', backref=db.backref('parent', remote_side=[id]), lazy=True)
     attachments = db.relationship('Attachment', backref='post', lazy=True)
+    flags = db.relationship('Flag', backref='post', lazy=True)
 
 
 class Attachment(db.Model):
@@ -42,6 +45,15 @@ class Attachment(db.Model):
     filename = db.Column(db.String(255), nullable=False)
     original_name = db.Column(db.String(255), nullable=False)
     post_id = db.Column(db.Integer, db.ForeignKey('post.id'), nullable=False)
+
+
+class Flag(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    reason = db.Column(db.String(255))
+    resolved = db.Column(db.Boolean, default=False)
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+    post_id = db.Column(db.Integer, db.ForeignKey('post.id'), nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
 
 
 @login_manager.user_loader

--- a/openbbs/templates/base.html
+++ b/openbbs/templates/base.html
@@ -25,6 +25,9 @@
         <li class="nav-item">
           <a class="nav-link" href="{{ url_for('main.trash') }}">Trash</a>
         </li>
+        <li class="nav-item">
+          <a class="nav-link" href="{{ url_for('main.flags') }}">Flags</a>
+        </li>
         {% endif %}
         <li class="nav-item">
           <a class="nav-link" href="{{ url_for('main.profile', username=current_user.username) }}">

--- a/openbbs/templates/flags.html
+++ b/openbbs/templates/flags.html
@@ -1,0 +1,19 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Flagged Posts</h2>
+<ul class="list-group">
+  {% for flg in flags %}
+  <li class="list-group-item">
+    <h6>{{ flg.post.title }} by {{ flg.post.author.username }} - flagged by {{ flg.reporter.username }}</h6>
+    <p>{{ flg.reason }}</p>
+    <form method="post" action="{{ url_for('main.resolve_flag', flag_id=flg.id) }}" class="d-inline">
+      <input type="hidden" name="token" value="{{ action_token(flg.post.id) }}">
+      <button class="btn btn-sm btn-outline-success" type="submit">Resolve</button>
+    </form>
+    <a href="{{ url_for('forums.view_forum', forum_id=flg.post.forum_id) }}" class="btn btn-sm btn-link">View</a>
+  </li>
+  {% else %}
+  <li class="list-group-item">No flags</li>
+  {% endfor %}
+</ul>
+{% endblock %}

--- a/openbbs/templates/forum_view.html
+++ b/openbbs/templates/forum_view.html
@@ -23,7 +23,9 @@
     {% if post.deleted %}
     <p class="fst-italic text-muted">This post has been deleted</p>
     {% else %}
-    <h5>{{ post.title }} {% if post.is_pinned %}<span class="badge bg-warning text-dark">Pinned</span>{% endif %}
+    <h5>{{ post.title }}
+      {% if post.is_pinned %}<span class="badge bg-warning text-dark">Pinned</span>{% endif %}
+      {% if post.is_locked %}<span class="badge bg-secondary">Locked</span>{% endif %}
       <small class="text-muted">by <a href="{{ url_for('main.profile', username=post.author.username, thread_id=post.id) }}">{{ post.author.username }}</a>
         {% if post.author.is_moderator %}<span class="badge bg-primary">Mod</span>{% endif %}
         (joined {{ post.author.created_at.strftime('%Y-%m-%d') }})
@@ -44,6 +46,16 @@
       <form method="post" action="{{ url_for(post.is_pinned and 'main.unpin_post' or 'main.pin_post', post_id=post.id) }}" class="d-inline">
         <input type="hidden" name="token" value="{{ action_token(post.id) }}">
         <button class="btn btn-sm btn-outline-secondary" type="submit">{{ 'Unpin' if post.is_pinned else 'Pin' }}</button>
+      </form>
+      <form method="post" action="{{ url_for(post.is_locked and 'main.unlock_post' or 'main.lock_post', post_id=post.id) }}" class="d-inline ms-1">
+        <input type="hidden" name="token" value="{{ action_token(post.id) }}">
+        <button class="btn btn-sm btn-outline-secondary" type="submit">{{ 'Unlock' if post.is_locked else 'Lock' }}</button>
+      </form>
+      {% endif %}
+      {% if current_user.is_authenticated and current_user.id != post.user_id %}
+      <form method="post" action="{{ url_for('main.flag_post', post_id=post.id) }}" class="d-inline ms-1">
+        <input type="hidden" name="token" value="{{ action_token(post.id) }}">
+        <button class="btn btn-sm btn-outline-warning" type="submit">Flag</button>
       </form>
       {% endif %}
     </div>
@@ -81,6 +93,7 @@
         {% endif %}
       </div>
     {% endfor %}
+    {% if not post.is_locked or current_user.is_moderator %}
     <form method="post" action="{{ url_for('main.create_post') }}" enctype="multipart/form-data" class="mt-3 autosave" data-key="post{{ post.id }}-reply">
       <input type="hidden" name="forum_id" value="{{ forum.id }}">
       <input type="hidden" name="parent_id" value="{{ post.id }}">
@@ -96,6 +109,9 @@
       <span class="draft-indicator">Draft saved</span>
       <button class="btn btn-secondary btn-sm" type="submit">Reply</button>
     </form>
+    {% else %}
+    <p class="text-muted">Thread locked</p>
+    {% endif %}
   </li>
   {% endfor %}
 </ul>


### PR DESCRIPTION
## Summary
- add `is_locked` post state and `Flag` model
- allow moderators or thread owners to lock/unlock threads
- enable users to flag posts for moderators
- show moderator links for Trash and Flags in the navbar
- display lock state and flag button in thread view

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687fb22d7618832aa8359c79e01f4652