### PR TITLE
Add preview and thread search

### DIFF
--- a/openbbs/static/drafts.js
+++ b/openbbs/static/drafts.js
@@ -1,19 +1,19 @@
 (function(){
-  function setup(form) {
+  function setupDraft(form){
     const key = form.dataset.key;
-    if (!key) return;
+    if(!key) return;
     const title = form.querySelector('input[name="title"]');
     const body = form.querySelector('textarea[name="body"]');
-    if (!body) return;
-    try {
+    if(!body) return;
+    try{
       const saved = localStorage.getItem(key);
-      if (saved) {
+      if(saved){
         const data = JSON.parse(saved);
-        if (data.body && !body.value) body.value = data.body;
-        if (title && data.title && !title.value) title.value = data.title;
+        if(data.body && !body.value) body.value = data.body;
+        if(title && data.title && !title.value) title.value = data.title;
         form.classList.add('draft-exists');
       }
-    } catch(e) {}
+    }catch(e){}
     const save = () => {
       const data = {
         title: title ? title.value : '',
@@ -23,10 +23,50 @@
       form.classList.add('draft-exists');
     };
     body.addEventListener('input', save);
-    if (title) title.addEventListener('input', save);
+    if(title) title.addEventListener('input', save);
     form.addEventListener('submit', () => localStorage.removeItem(key));
   }
+
+  function setupPreview(form){
+    const btn = form.querySelector('.preview-btn');
+    const area = form.querySelector('textarea[name="body"]');
+    const box = form.querySelector('.preview');
+    if(!btn || !area || !box) return;
+    btn.addEventListener('click', async () => {
+      if(!box.classList.contains('d-none')){
+        box.classList.add('d-none');
+        btn.textContent = 'Preview';
+        return;
+      }
+      const resp = await fetch('/preview', {
+        method:'POST',
+        headers:{'Content-Type':'application/json'},
+        body: JSON.stringify({text: area.value})
+      });
+      const data = await resp.json();
+      box.innerHTML = data.html;
+      box.classList.remove('d-none');
+      btn.textContent = 'Hide Preview';
+    });
+  }
+
+  function setupThreadSearch(){
+    const input = document.getElementById('thread-search');
+    if(!input) return;
+    const items = document.querySelectorAll('#posts-list .post-item');
+    input.addEventListener('input', () => {
+      const q = input.value.toLowerCase();
+      items.forEach(it => {
+        const text = it.innerText.toLowerCase();
+        if(text.includes(q)) it.classList.remove('d-none');
+        else it.classList.add('d-none');
+      });
+    });
+  }
+
   document.addEventListener('DOMContentLoaded', () => {
-    document.querySelectorAll('form.autosave').forEach(setup);
+    document.querySelectorAll('form.autosave').forEach(setupDraft);
+    document.querySelectorAll('form').forEach(setupPreview);
+    setupThreadSearch();
   });
 })();

--- a/openbbs/templates/edit_post.html
+++ b/openbbs/templates/edit_post.html
@@ -9,6 +9,10 @@
   <div class="mb-3">
     <textarea class="form-control" name="body" rows="4" required>{{ post.body }}</textarea>
   </div>
+  <div class="mb-3">
+    <button class="btn btn-outline-secondary preview-btn" type="button">Preview</button>
+  </div>
+  <div class="preview border p-2 mb-3 d-none"></div>
   <span class="draft-indicator">Draft saved</span>
   <button class="btn btn-success" type="submit">Save</button>
   <a href="{{ url_for('forums.view_forum', forum_id=post.forum_id) }}" class="btn btn-secondary">Cancel</a>

--- a/openbbs/templates/forum_view.html
+++ b/openbbs/templates/forum_view.html
@@ -3,6 +3,9 @@
 <a class="btn btn-link" href="{{ url_for('forums.list_forums') }}">&larr; Back to Forums</a>
 <h2>{{ forum.name }}</h2>
 <p>{{ forum.description }}</p>
+<div class="mb-3">
+  <input class="form-control" type="text" id="thread-search" placeholder="Search this thread">
+</div>
 <form method="post" action="{{ url_for('main.create_post') }}" enctype="multipart/form-data" class="mb-3 autosave" data-key="forum{{ forum.id }}-new">
   <input type="hidden" name="forum_id" value="{{ forum.id }}">
   <div class="mb-3">
@@ -12,14 +15,18 @@
     <textarea class="form-control" name="body" rows="4" placeholder="Message" required></textarea>
   </div>
   <div class="mb-3">
+    <button class="btn btn-outline-secondary preview-btn" type="button">Preview</button>
+  </div>
+  <div class="preview border p-2 mb-3 d-none"></div>
+  <div class="mb-3">
     <input class="form-control" type="file" name="attachment">
   </div>
   <span class="draft-indicator">Draft saved</span>
   <button class="btn btn-success" type="submit">Post</button>
 </form>
-<ul class="list-group">
+<ul class="list-group" id="posts-list">
   {% for post in posts %}
-  <li class="list-group-item">
+  <li class="list-group-item post-item">
     {% if post.deleted %}
     <p class="fst-italic text-muted">This post has been deleted</p>
     {% else %}
@@ -103,6 +110,10 @@
       <div class="mb-2">
         <textarea class="form-control" name="body" rows="2" placeholder="Reply" required></textarea>
       </div>
+      <div class="mb-2">
+        <button class="btn btn-outline-secondary btn-sm preview-btn" type="button">Preview</button>
+      </div>
+      <div class="preview border p-2 mb-2 d-none"></div>
       <div class="mb-2">
         <input class="form-control" type="file" name="attachment">
       </div>

--- a/openbbs/views.py
+++ b/openbbs/views.py
@@ -11,6 +11,7 @@ from .models import Post, Forum, Attachment, User, Flag
 from . import db
 from werkzeug.utils import secure_filename
 from pathlib import Path
+import markdown
 
 main_bp = Blueprint('main', __name__)
 
@@ -69,6 +70,15 @@ def verify_owner_token(post: Post) -> bool:
         return False
     expected = generate_owner_token(post.id, post.user_id)
     return hmac.compare_digest(expected, post.owner_token)
+
+
+@main_bp.route('/preview', methods=['POST'])
+@login_required
+def preview_markdown():
+    """Return HTML preview for provided markdown text."""
+    text = request.get_json(force=True).get('text', '')
+    html = markdown.markdown(text)
+    return {'html': html}
 
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pyserial
 reedsolo
 crcmod
 cryptography
+markdown


### PR DESCRIPTION
## Summary
- enable markdown preview for posts
- allow searching within a thread
- support preview on edit and reply forms
- update client scripts accordingly
- include `markdown` in requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687fb4ce22f0832a9e9f8937a3df5b71