### PR TITLE
Improve forum UX

### DIFF
--- a/openbbs/static/drafts.js
+++ b/openbbs/static/drafts.js
@@ -24,7 +24,17 @@
     };
     body.addEventListener('input', save);
     if(title) title.addEventListener('input', save);
-    form.addEventListener('submit', () => localStorage.removeItem(key));
+    const warn = (e) => {
+      if(form.classList.contains('draft-exists')){
+        e.preventDefault();
+        e.returnValue = '';
+      }
+    };
+    window.addEventListener('beforeunload', warn);
+    form.addEventListener('submit', () => {
+      localStorage.removeItem(key);
+      window.removeEventListener('beforeunload', warn);
+    });
   }
 
   function setupPreview(form){
@@ -64,9 +74,36 @@
     });
   }
 
+  function setupShortcuts(){
+    document.addEventListener('keydown', (e) => {
+      if(e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
+      const key = e.key.toLowerCase();
+      if(key === 'n'){
+        const el = document.getElementById('new-topic-title');
+        if(el){
+          e.preventDefault();
+          el.focus();
+        }
+      } else if(key === 'e'){
+        const edit = document.querySelector('.shortcut-edit');
+        if(edit){
+          e.preventDefault();
+          edit.click();
+        }
+      } else if(key === 'f'){
+        const flag = document.querySelector('.shortcut-flag');
+        if(flag){
+          e.preventDefault();
+          flag.submit();
+        }
+      }
+    });
+  }
+
   document.addEventListener('DOMContentLoaded', () => {
     document.querySelectorAll('form.autosave').forEach(setupDraft);
     document.querySelectorAll('form').forEach(setupPreview);
     setupThreadSearch();
+    setupShortcuts();
   });
 })();

--- a/openbbs/templates/base.html
+++ b/openbbs/templates/base.html
@@ -13,7 +13,7 @@
     <a class="navbar-brand" href="{{ url_for('main.index') }}">OpenBBS</a>
     <div class="collapse navbar-collapse">
       <form class="d-flex me-auto" method="get" action="{{ url_for('main.search') }}">
-        <input class="form-control me-2" type="search" name="q" placeholder="Search">
+        <input class="form-control me-2" id="global-search" aria-label="Search site" type="search" name="q" placeholder="Search">
         <button class="btn btn-outline-success" type="submit">Search</button>
       </form>
       <ul class="navbar-nav ms-auto">

--- a/openbbs/templates/edit_post.html
+++ b/openbbs/templates/edit_post.html
@@ -13,7 +13,7 @@
     <button class="btn btn-outline-secondary preview-btn" type="button">Preview</button>
   </div>
   <div class="preview border p-2 mb-3 d-none"></div>
-  <span class="draft-indicator">Draft saved</span>
+  <span class="draft-indicator">You have an unsaved draft</span>
   <button class="btn btn-success" type="submit">Save</button>
   <a href="{{ url_for('forums.view_forum', forum_id=post.forum_id) }}" class="btn btn-secondary">Cancel</a>
 </form>

--- a/openbbs/templates/forum_view.html
+++ b/openbbs/templates/forum_view.html
@@ -4,12 +4,12 @@
 <h2>{{ forum.name }}</h2>
 <p>{{ forum.description }}</p>
 <div class="mb-3">
-  <input class="form-control" type="text" id="thread-search" placeholder="Search this thread">
+  <input class="form-control" type="text" id="thread-search" aria-label="Search within thread" placeholder="Search this thread">
 </div>
 <form method="post" action="{{ url_for('main.create_post') }}" enctype="multipart/form-data" class="mb-3 autosave" data-key="forum{{ forum.id }}-new">
   <input type="hidden" name="forum_id" value="{{ forum.id }}">
   <div class="mb-3">
-    <input class="form-control" type="text" name="title" placeholder="Title" required>
+    <input class="form-control" id="new-topic-title" type="text" name="title" placeholder="Title" required>
   </div>
   <div class="mb-3">
     <textarea class="form-control" name="body" rows="4" placeholder="Message" required></textarea>
@@ -21,7 +21,7 @@
   <div class="mb-3">
     <input class="form-control" type="file" name="attachment">
   </div>
-  <span class="draft-indicator">Draft saved</span>
+  <span class="draft-indicator">You have an unsaved draft</span>
   <button class="btn btn-success" type="submit">Post</button>
 </form>
 <ul class="list-group" id="posts-list">
@@ -44,7 +44,7 @@
     <p>{{ post.body }}</p>
     {% if current_user.is_authenticated and (current_user.is_moderator or current_user.id == post.user_id) %}
     <div class="mb-2">
-      <a href="{{ url_for('main.edit_post', post_id=post.id) }}" class="btn btn-sm btn-outline-primary">Edit</a>
+      <a href="{{ url_for('main.edit_post', post_id=post.id) }}" class="btn btn-sm btn-outline-primary shortcut-edit">Edit</a>
       <form method="post" action="{{ url_for('main.delete_post', post_id=post.id) }}" class="d-inline">
         <input type="hidden" name="token" value="{{ action_token(post.id) }}">
         <button class="btn btn-sm btn-outline-danger" type="submit">Delete</button>
@@ -60,7 +60,7 @@
       </form>
       {% endif %}
       {% if current_user.is_authenticated and current_user.id != post.user_id %}
-      <form method="post" action="{{ url_for('main.flag_post', post_id=post.id) }}" class="d-inline ms-1">
+      <form method="post" action="{{ url_for('main.flag_post', post_id=post.id) }}" class="d-inline ms-1 shortcut-flag">
         <input type="hidden" name="token" value="{{ action_token(post.id) }}">
         <button class="btn btn-sm btn-outline-warning" type="submit">Flag</button>
       </form>
@@ -90,7 +90,7 @@
         {% endfor %}
         {% if current_user.is_authenticated and (current_user.is_moderator or current_user.id == reply.user_id) %}
         <div class="mb-2">
-          <a href="{{ url_for('main.edit_post', post_id=reply.id) }}" class="btn btn-sm btn-outline-primary">Edit</a>
+          <a href="{{ url_for('main.edit_post', post_id=reply.id) }}" class="btn btn-sm btn-outline-primary shortcut-edit">Edit</a>
           <form method="post" action="{{ url_for('main.delete_post', post_id=reply.id) }}" class="d-inline">
             <input type="hidden" name="token" value="{{ action_token(reply.id) }}">
             <button class="btn btn-sm btn-outline-danger" type="submit">Delete</button>
@@ -117,7 +117,7 @@
       <div class="mb-2">
         <input class="form-control" type="file" name="attachment">
       </div>
-      <span class="draft-indicator">Draft saved</span>
+      <span class="draft-indicator">You have an unsaved draft</span>
       <button class="btn btn-secondary btn-sm" type="submit">Reply</button>
     </form>
     {% else %}


### PR DESCRIPTION
## Summary
- add ARIA labels and keyboard shortcuts
- warn before closing when drafts exist
- show unsaved draft indicator in forms

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687fb7bd2fa4832aa6b907561c9c8fbd