### PR TITLE
Implement topic move feature

### DIFF
--- a/openbbs/templates/forum_view.html
+++ b/openbbs/templates/forum_view.html
@@ -59,6 +59,7 @@
         <input type="hidden" name="token" value="{{ action_token(post.id) }}">
         <button class="btn btn-sm btn-outline-secondary" type="submit">{{ 'Unlock' if post.is_locked else 'Lock' }}</button>
       </form>
+      <a href="{{ url_for('main.move_post', post_id=post.id) }}" class="btn btn-sm btn-outline-secondary ms-1">Move</a>
       {% endif %}
       {% if current_user.is_authenticated and current_user.id != post.user_id %}
       <form method="post" action="{{ url_for('main.flag_post', post_id=post.id) }}" class="d-inline ms-1 shortcut-flag">

--- a/openbbs/templates/move_post.html
+++ b/openbbs/templates/move_post.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Move Topic</h2>
+<form method="post">
+  <input type="hidden" name="token" value="{{ token }}">
+  <div class="mb-3">
+    <label class="form-label" for="forum_id">Destination Forum</label>
+    <select class="form-select" name="forum_id" id="forum_id" required>
+      {% for f in forums %}
+      <option value="{{ f.id }}" {% if f.id == post.forum_id %}selected{% endif %}>{{ f.name }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <button class="btn btn-primary" type="submit">Move</button>
+  <a class="btn btn-secondary" href="{{ url_for('forums.view_forum', forum_id=post.forum_id) }}">Cancel</a>
+</form>
+{% endblock %}

--- a/openbbs/views.py
+++ b/openbbs/views.py
@@ -340,6 +340,38 @@ def unlock_post(post_id):
     return redirect(url_for('forums.view_forum', forum_id=post.forum_id))
 
 
+@main_bp.route('/post/<int:post_id>/move', methods=['GET', 'POST'])
+@login_required
+def move_post(post_id):
+    post = Post.query.get_or_404(post_id)
+    if post.parent_id is not None:
+        return redirect(url_for('forums.view_forum', forum_id=post.forum_id))
+    if not current_user.is_moderator:
+        return redirect(url_for('forums.view_forum', forum_id=post.forum_id))
+    if request.method == 'POST':
+        token = request.form.get('token')
+        if not verify_action_token(post.id, token):
+            return redirect(url_for('forums.view_forum', forum_id=post.forum_id))
+        forum_id = request.form.get('forum_id', type=int)
+        forum = Forum.query.get(forum_id)
+        if forum:
+            def _move_recursive(p: Post):
+                p.forum_id = forum_id
+                for child in p.children:
+                    _move_recursive(child)
+            _move_recursive(post)
+            db.session.commit()
+            try:
+                from .forums import get_forum_posts
+                get_forum_posts.cache_clear()
+            except Exception:
+                pass
+            return redirect(url_for('forums.view_forum', forum_id=forum_id))
+    forums = Forum.query.all()
+    token = generate_action_token(post.id)
+    return render_template('move_post.html', post=post, forums=forums, token=token)
+
+
 @main_bp.route('/attachment/<int:att_id>')
 @login_required
 def get_attachment(att_id):

--- a/tests/test_move_topic.py
+++ b/tests/test_move_topic.py
@@ -1,0 +1,45 @@
+from openbbs import create_app, db
+from openbbs.models import User, Forum, Post
+from openbbs.views import generate_action_token
+import pytest
+
+@pytest.fixture
+def app_ctx(tmp_path):
+    app = create_app()
+    app.config['SQLALCHEMY_DATABASE_URI'] = f'sqlite:///{tmp_path / "test.db"}'
+    app.config['TESTING'] = True
+    with app.app_context():
+        db.create_all()
+        yield app
+
+@pytest.fixture
+def client(app_ctx):
+    return app_ctx.test_client()
+
+
+def create_user(username, is_mod=False):
+    user = User(username=username, password='pw', is_moderator=is_mod)
+    db.session.add(user)
+    db.session.commit()
+    return user
+
+
+def login(client, username):
+    with client.session_transaction() as sess:
+        sess['_user_id'] = str(User.query.filter_by(username=username).first().id)
+
+
+def test_move_topic(app_ctx, client):
+    mod = create_user('mod', is_mod=True)
+    forum1 = Forum(name='f1')
+    forum2 = Forum(name='f2')
+    db.session.add_all([forum1, forum2])
+    db.session.commit()
+    post = Post(title='t', body='b', author=mod, forum=forum1)
+    db.session.add(post)
+    db.session.commit()
+    login(client, 'mod')
+    token = generate_action_token(post.id, mod.id)
+    resp = client.post(f'/post/{post.id}/move', data={'forum_id': forum2.id, 'token': token})
+    assert resp.status_code == 302
+    assert Post.query.get(post.id).forum_id == forum2.id


### PR DESCRIPTION
## Summary
- add moderator-only interface to move a topic to another forum
- expose `move_post` route in `views.py`
- add Move button in forum view
- create template for selecting destination forum
- test moving topics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687fbc13b1cc832a9ddadfc318be5269