### PR TITLE
Add moderator notes capability

### DIFF
--- a/openbbs/__init__.py
+++ b/openbbs/__init__.py
@@ -34,7 +34,7 @@ def create_app():
     db.init_app(app)
     login_manager.init_app(app)
 
-    from .models import User, Post, Forum, Attachment, Flag, PostVersion
+    from .models import User, Post, Forum, Attachment, Flag, PostVersion, ModNote
 
     with app.app_context():
         Path(app.config['UPLOAD_FOLDER']).mkdir(exist_ok=True)

--- a/openbbs/models.py
+++ b/openbbs/models.py
@@ -13,6 +13,10 @@ class User(db.Model, UserMixin):
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     posts = db.relationship('Post', backref='author', lazy=True)
     flags = db.relationship('Flag', backref='reporter', lazy=True)
+    received_notes = db.relationship('ModNote', foreign_keys='ModNote.user_id',
+                                     backref='target', lazy=True)
+    sent_notes = db.relationship('ModNote', foreign_keys='ModNote.mod_id',
+                                 backref='moderator', lazy=True)
 
 
 class Forum(db.Model):
@@ -64,6 +68,15 @@ class PostVersion(db.Model):
     body = db.Column(db.Text, nullable=False)
     timestamp = db.Column(db.DateTime, default=datetime.utcnow)
     post_id = db.Column(db.Integer, db.ForeignKey('post.id'), nullable=False)
+
+
+class ModNote(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    text = db.Column(db.Text, nullable=False)
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    mod_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    post_id = db.Column(db.Integer, db.ForeignKey('post.id'))
 
 
 @login_manager.user_loader

--- a/openbbs/static/drafts.js
+++ b/openbbs/static/drafts.js
@@ -100,10 +100,26 @@
     });
   }
 
+  function setupWarnForms(){
+    document.querySelectorAll('.warn-form').forEach(form => {
+      form.addEventListener('submit', e => {
+        const input = form.querySelector('input[name="text"]');
+        if(!input) return;
+        const val = prompt('Enter warning note:');
+        if(!val){
+          e.preventDefault();
+          return;
+        }
+        input.value = val;
+      });
+    });
+  }
+
   document.addEventListener('DOMContentLoaded', () => {
     document.querySelectorAll('form.autosave').forEach(setupDraft);
     document.querySelectorAll('form').forEach(setupPreview);
     setupThreadSearch();
     setupShortcuts();
+    setupWarnForms();
   });
 })();

--- a/openbbs/templates/forum_view.html
+++ b/openbbs/templates/forum_view.html
@@ -26,7 +26,7 @@
 </form>
 <ul class="list-group" id="posts-list">
   {% for post in posts %}
-  <li class="list-group-item post-item">
+  <li class="list-group-item post-item" id="post{{ post.id }}">
     {% if post.deleted %}
     <p class="fst-italic text-muted">This post has been deleted</p>
     {% else %}
@@ -67,6 +67,14 @@
         <button class="btn btn-sm btn-outline-warning" type="submit">Flag</button>
       </form>
       {% endif %}
+      {% if current_user.is_authenticated and current_user.is_moderator and current_user.id != post.user_id %}
+      <form method="post" action="{{ url_for('main.warn_user', user_id=post.user_id) }}" class="d-inline ms-1 warn-form">
+        <input type="hidden" name="token" value="{{ action_token(post.user_id) }}">
+        <input type="hidden" name="post_id" value="{{ post.id }}">
+        <input type="hidden" name="text" value="">
+        <button class="btn btn-sm btn-outline-warning" type="submit">Warn</button>
+      </form>
+      {% endif %}
     </div>
     {% endif %}
     {% for att in post.attachments %}
@@ -74,7 +82,7 @@
     {% endfor %}
     {% endif %}
     {% for reply in post.children %}
-      <div class="mt-3 ms-3 border-start ps-3">
+      <div class="mt-3 ms-3 border-start ps-3" id="post{{ reply.id }}">
         {% if reply.deleted %}
         <p class="fst-italic text-muted">This post has been deleted</p>
         {% else %}
@@ -94,13 +102,21 @@
         <div class="mb-2">
           <a href="{{ url_for('main.edit_post', post_id=reply.id) }}" class="btn btn-sm btn-outline-primary shortcut-edit">Edit</a>
           <a href="{{ url_for('main.post_history', post_id=reply.id) }}" class="btn btn-sm btn-outline-secondary">History</a>
-          <form method="post" action="{{ url_for('main.delete_post', post_id=reply.id) }}" class="d-inline">
-            <input type="hidden" name="token" value="{{ action_token(reply.id) }}">
-            <button class="btn btn-sm btn-outline-danger" type="submit">Delete</button>
-          </form>
-        </div>
+        <form method="post" action="{{ url_for('main.delete_post', post_id=reply.id) }}" class="d-inline">
+          <input type="hidden" name="token" value="{{ action_token(reply.id) }}">
+          <button class="btn btn-sm btn-outline-danger" type="submit">Delete</button>
+        </form>
+        {% if current_user.is_moderator and current_user.id != reply.user_id %}
+        <form method="post" action="{{ url_for('main.warn_user', user_id=reply.user_id) }}" class="d-inline ms-1 warn-form">
+          <input type="hidden" name="token" value="{{ action_token(reply.user_id) }}">
+          <input type="hidden" name="post_id" value="{{ reply.id }}">
+          <input type="hidden" name="text" value="">
+          <button class="btn btn-sm btn-outline-warning" type="submit">Warn</button>
+        </form>
         {% endif %}
-        {% endif %}
+      </div>
+      {% endif %}
+      {% endif %}
       </div>
     {% endfor %}
     {% if not post.is_locked or current_user.is_moderator %}

--- a/openbbs/templates/profile.html
+++ b/openbbs/templates/profile.html
@@ -10,6 +10,28 @@
   <button class="btn btn-sm btn-outline-secondary" type="submit">{{ 'Revoke Moderator' if user.is_moderator else 'Make Moderator' }}</button>
 </form>
 {% endif %}
+{% if current_user.is_authenticated and current_user.is_moderator and current_user.id != user.id %}
+<form method="post" action="{{ url_for('main.warn_user', user_id=user.id) }}" class="mb-3 warn-form">
+  <input type="hidden" name="token" value="{{ token }}">
+  <input type="hidden" name="post_id" value="">
+  <input type="hidden" name="text" value="">
+  <button class="btn btn-sm btn-outline-warning" type="submit">Add Mod Note</button>
+</form>
+{% endif %}
+{% if (current_user.is_authenticated and current_user.is_moderator) or current_user.id == user.id %}
+{% if user.received_notes %}
+<h3>Mod Notes</h3>
+<ul class="list-group mb-3">
+  {% for n in user.received_notes %}
+  <li class="list-group-item">
+    <small class="text-muted">{{ n.timestamp.strftime('%Y-%m-%d %H:%M') }} by {{ n.moderator.username }}</small>
+    <p>{{ n.text }}</p>
+    {% if n.post %}<small>Post: <a href="{{ url_for('forums.view_forum', forum_id=n.post.forum_id) }}">{{ n.post.title }}</a></small>{% endif %}
+  </li>
+  {% endfor %}
+</ul>
+{% endif %}
+{% endif %}
 <h3>Posts</h3>
 <ul class="list-group">
   {% for p in posts %}

--- a/tests/test_warn_user.py
+++ b/tests/test_warn_user.py
@@ -1,0 +1,48 @@
+from openbbs import create_app, db
+from openbbs.models import User, Forum, Post, ModNote
+from openbbs.views import generate_action_token
+import pytest
+
+@pytest.fixture
+def app_ctx(tmp_path):
+    app = create_app()
+    app.config['SQLALCHEMY_DATABASE_URI'] = f'sqlite:///{tmp_path / "test.db"}'
+    app.config['TESTING'] = True
+    with app.app_context():
+        db.create_all()
+        yield app
+
+@pytest.fixture
+def client(app_ctx):
+    return app_ctx.test_client()
+
+
+def create_user(username, is_mod=False):
+    user = User(username=username, password='pw', is_moderator=is_mod)
+    db.session.add(user)
+    db.session.commit()
+    return user
+
+
+def login(client, username):
+    with client.session_transaction() as sess:
+        sess['_user_id'] = str(User.query.filter_by(username=username).first().id)
+
+
+def test_warn_user_creates_note(app_ctx, client):
+    mod = create_user('mod', is_mod=True)
+    user = create_user('bob')
+    forum = Forum(name='f1')
+    db.session.add(forum)
+    db.session.commit()
+    post = Post(title='t', body='b', author=user, forum=forum)
+    db.session.add(post)
+    db.session.commit()
+    login(client, 'mod')
+    token = generate_action_token(user.id, mod.id)
+    resp = client.post(f'/user/{user.id}/warn', data={'token': token, 'text': 'bad', 'post_id': post.id})
+    assert resp.status_code == 302
+    note = ModNote.query.filter_by(user_id=user.id).first()
+    assert note is not None
+    assert note.text == 'bad'
+    assert note.post_id == post.id


### PR DESCRIPTION
## Summary
- allow moderators to attach notes/warnings to users
- store notes in new `ModNote` model
- provide JS prompt for warning submission
- add warn buttons in thread posts and on profile page
- display notes on profile
- test moderator warning feature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687fc31aa698832a87b8994d838fe9cf