### PR TITLE
Improve thread search UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Additional usage information is available in [docs/USAGE.md](docs/USAGE.md).
 - REST API for threads/messages and lightweight offline UI
 - Local SQLite storage with sync log
 - Thread owners can grant moderator status via signed ownership tokens
+- Keyboard shortcuts for quick actions and "/" to focus the search box
 
 ## Setup
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -10,6 +10,7 @@ This guide provides an overview of running the server, using the web interface a
 
 On first launch you can sign up for a new account. Forums and posts are stored in a local SQLite database `openbbs.db`.
 Thread owners can promote other users to moderator status by visiting their profile from the thread page.
+The web interface supports several keyboard shortcuts: press `N` to start a new topic, `E` to edit a post, `F` to flag content and `/` to jump to the search box. Text entered in the thread search field highlights matching posts.
 
 ## Command Line Interface
 

--- a/openbbs/static/drafts.css
+++ b/openbbs/static/drafts.css
@@ -1,2 +1,3 @@
 .draft-indicator{display:none;color:#d63384;font-size:0.9em;}
 form.draft-exists .draft-indicator{display:inline;}
+mark{background-color:#ffe599;padding:0 2px;}

--- a/openbbs/static/drafts.js
+++ b/openbbs/static/drafts.js
@@ -64,12 +64,24 @@
     const input = document.getElementById('thread-search');
     if(!input) return;
     const items = document.querySelectorAll('#posts-list .post-item');
+    const originals = new Map();
+    items.forEach(it => originals.set(it, it.innerHTML));
     input.addEventListener('input', () => {
       const q = input.value.toLowerCase();
       items.forEach(it => {
+        it.innerHTML = originals.get(it);
         const text = it.innerText.toLowerCase();
-        if(text.includes(q)) it.classList.remove('d-none');
-        else it.classList.add('d-none');
+        if(!q){
+          it.classList.remove('d-none');
+          return;
+        }
+        if(text.includes(q)){
+          it.classList.remove('d-none');
+          const regex = new RegExp('('+q.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&')+')', 'gi');
+          it.innerHTML = it.innerHTML.replace(regex, '<mark>$1</mark>');
+        }else{
+          it.classList.add('d-none');
+        }
       });
     });
   }
@@ -95,6 +107,12 @@
         if(flag){
           e.preventDefault();
           flag.submit();
+        }
+      } else if(key === '/' || key === 's'){
+        const search = document.getElementById('global-search');
+        if(search){
+          e.preventDefault();
+          search.focus();
         }
       }
     });


### PR DESCRIPTION
## Summary
- highlight matches in thread search results
- add keyboard shortcuts for focusing search
- document new shortcuts

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687fc60261f0832a876bcd2fa7e6bdcf