### PR TITLE
Add moderation delete reasons and search suggestions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ __pycache__/
 uploads/*
 !uploads/.gitkeep
 sync.log
+openbbs.db
+encryption.key
+instance/

--- a/openbbs/models.py
+++ b/openbbs/models.py
@@ -11,19 +11,21 @@ class User(db.Model, UserMixin):
     reputation = db.Column(db.Integer, default=0)
     is_moderator = db.Column(db.Boolean, default=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
-    posts = db.relationship('Post', backref='author', lazy=True)
-    flags = db.relationship('Flag', backref='reporter', lazy=True)
-    received_notes = db.relationship('ModNote', foreign_keys='ModNote.user_id',
-                                     backref='target', lazy=True)
-    sent_notes = db.relationship('ModNote', foreign_keys='ModNote.mod_id',
-                                 backref='moderator', lazy=True)
+    posts = db.relationship("Post", backref="author", lazy=True)
+    flags = db.relationship("Flag", backref="reporter", lazy=True)
+    received_notes = db.relationship(
+        "ModNote", foreign_keys="ModNote.user_id", backref="target", lazy=True
+    )
+    sent_notes = db.relationship(
+        "ModNote", foreign_keys="ModNote.mod_id", backref="moderator", lazy=True
+    )
 
 
 class Forum(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(150), unique=True, nullable=False)
     description = db.Column(db.Text, default="")
-    posts = db.relationship('Post', backref='forum', lazy=True)
+    posts = db.relationship("Post", backref="forum", lazy=True)
 
 
 class Post(db.Model):
@@ -33,24 +35,31 @@ class Post(db.Model):
     timestamp = db.Column(db.DateTime, default=datetime.utcnow)
     edited_at = db.Column(db.DateTime)
     deleted = db.Column(db.Boolean, default=False)
+    delete_reason = db.Column(db.String(255))
     is_pinned = db.Column(db.Boolean, default=False)
     is_locked = db.Column(db.Boolean, default=False)
     owner_token = db.Column(db.String(64))
-    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
-    forum_id = db.Column(db.Integer, db.ForeignKey('forum.id'), nullable=False)
-    parent_id = db.Column(db.Integer, db.ForeignKey('post.id'))
-    children = db.relationship('Post', backref=db.backref('parent', remote_side=[id]), lazy=True)
-    attachments = db.relationship('Attachment', backref='post', lazy=True)
-    flags = db.relationship('Flag', backref='post', lazy=True)
-    versions = db.relationship('PostVersion', backref='post', lazy=True,
-                               order_by="PostVersion.timestamp.desc()")
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    forum_id = db.Column(db.Integer, db.ForeignKey("forum.id"), nullable=False)
+    parent_id = db.Column(db.Integer, db.ForeignKey("post.id"))
+    children = db.relationship(
+        "Post", backref=db.backref("parent", remote_side=[id]), lazy=True
+    )
+    attachments = db.relationship("Attachment", backref="post", lazy=True)
+    flags = db.relationship("Flag", backref="post", lazy=True)
+    versions = db.relationship(
+        "PostVersion",
+        backref="post",
+        lazy=True,
+        order_by="PostVersion.timestamp.desc()",
+    )
 
 
 class Attachment(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     filename = db.Column(db.String(255), nullable=False)
     original_name = db.Column(db.String(255), nullable=False)
-    post_id = db.Column(db.Integer, db.ForeignKey('post.id'), nullable=False)
+    post_id = db.Column(db.Integer, db.ForeignKey("post.id"), nullable=False)
 
 
 class Flag(db.Model):
@@ -58,8 +67,8 @@ class Flag(db.Model):
     reason = db.Column(db.String(255))
     resolved = db.Column(db.Boolean, default=False)
     timestamp = db.Column(db.DateTime, default=datetime.utcnow)
-    post_id = db.Column(db.Integer, db.ForeignKey('post.id'), nullable=False)
-    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    post_id = db.Column(db.Integer, db.ForeignKey("post.id"), nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
 
 
 class PostVersion(db.Model):
@@ -67,16 +76,16 @@ class PostVersion(db.Model):
     title = db.Column(db.String(255), nullable=False)
     body = db.Column(db.Text, nullable=False)
     timestamp = db.Column(db.DateTime, default=datetime.utcnow)
-    post_id = db.Column(db.Integer, db.ForeignKey('post.id'), nullable=False)
+    post_id = db.Column(db.Integer, db.ForeignKey("post.id"), nullable=False)
 
 
 class ModNote(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     text = db.Column(db.Text, nullable=False)
     timestamp = db.Column(db.DateTime, default=datetime.utcnow)
-    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
-    mod_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
-    post_id = db.Column(db.Integer, db.ForeignKey('post.id'))
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    mod_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    post_id = db.Column(db.Integer, db.ForeignKey("post.id"))
 
 
 @login_manager.user_loader

--- a/openbbs/static/drafts.js
+++ b/openbbs/static/drafts.js
@@ -133,11 +133,43 @@
     });
   }
 
+  function setupDeleteForms(){
+    document.querySelectorAll('.delete-form').forEach(form => {
+      form.addEventListener('submit', e => {
+        const input = form.querySelector('input[name="reason"]');
+        if(input){
+          const val = prompt('Reason for deletion (optional):');
+          input.value = val || '';
+        }
+      });
+    });
+  }
+
+  function setupSearchSuggest(){
+    const box = document.getElementById('global-search');
+    const list = document.getElementById('search-list');
+    if(!box || !list) return;
+    let ctrl;
+    box.addEventListener('input', () => {
+      const q = box.value.trim();
+      if(ctrl) ctrl.abort();
+      if(!q){ list.innerHTML=''; return; }
+      ctrl = new AbortController();
+      fetch('/suggest?q='+encodeURIComponent(q), {signal: ctrl.signal})
+        .then(r => r.json())
+        .then(data => {
+          list.innerHTML = data.results.map(r => `<option value="${r.title}">`).join('');
+        }).catch(()=>{});
+    });
+  }
+
   document.addEventListener('DOMContentLoaded', () => {
     document.querySelectorAll('form.autosave').forEach(setupDraft);
     document.querySelectorAll('form').forEach(setupPreview);
     setupThreadSearch();
     setupShortcuts();
     setupWarnForms();
+    setupDeleteForms();
+    setupSearchSuggest();
   });
 })();

--- a/openbbs/templates/base.html
+++ b/openbbs/templates/base.html
@@ -13,7 +13,8 @@
     <a class="navbar-brand" href="{{ url_for('main.index') }}">OpenBBS</a>
     <div class="collapse navbar-collapse">
       <form class="d-flex me-auto" method="get" action="{{ url_for('main.search') }}">
-        <input class="form-control me-2" id="global-search" aria-label="Search site" type="search" name="q" placeholder="Search">
+        <input class="form-control me-2" id="global-search" list="search-list" aria-label="Search site" type="search" name="q" placeholder="Search">
+        <datalist id="search-list"></datalist>
         <button class="btn btn-outline-success" type="submit">Search</button>
       </form>
       <ul class="navbar-nav ms-auto">

--- a/openbbs/templates/flags.html
+++ b/openbbs/templates/flags.html
@@ -10,6 +10,11 @@
       <input type="hidden" name="token" value="{{ action_token(flg.post.id) }}">
       <button class="btn btn-sm btn-outline-success" type="submit">Resolve</button>
     </form>
+    <form method="post" action="{{ url_for('main.delete_flagged_post', flag_id=flg.id) }}" class="d-inline delete-form ms-1">
+      <input type="hidden" name="token" value="{{ action_token(flg.post.id) }}">
+      <input type="hidden" name="reason" value="">
+      <button class="btn btn-sm btn-outline-danger" type="submit">Delete</button>
+    </form>
     <a href="{{ url_for('forums.view_forum', forum_id=flg.post.forum_id) }}" class="btn btn-sm btn-link">View</a>
   </li>
   {% else %}

--- a/openbbs/templates/forum_view.html
+++ b/openbbs/templates/forum_view.html
@@ -28,7 +28,7 @@
   {% for post in posts %}
   <li class="list-group-item post-item" id="post{{ post.id }}">
     {% if post.deleted %}
-    <p class="fst-italic text-muted">This post has been deleted</p>
+    <p class="fst-italic text-muted">This post has been deleted{% if post.delete_reason %}: {{ post.delete_reason }}{% endif %}</p>
     {% else %}
     <h5>{{ post.title }}
       {% if post.is_pinned %}<span class="badge bg-warning text-dark">Pinned</span>{% endif %}
@@ -46,8 +46,9 @@
     <div class="mb-2">
         <a href="{{ url_for('main.edit_post', post_id=post.id) }}" class="btn btn-sm btn-outline-primary shortcut-edit">Edit</a>
         <a href="{{ url_for('main.post_history', post_id=post.id) }}" class="btn btn-sm btn-outline-secondary">History</a>
-      <form method="post" action="{{ url_for('main.delete_post', post_id=post.id) }}" class="d-inline">
+      <form method="post" action="{{ url_for('main.delete_post', post_id=post.id) }}" class="d-inline delete-form">
         <input type="hidden" name="token" value="{{ action_token(post.id) }}">
+        {% if current_user.is_moderator %}<input type="hidden" name="reason" value="">{% endif %}
         <button class="btn btn-sm btn-outline-danger" type="submit">Delete</button>
       </form>
       {% if current_user.is_moderator and post.parent_id is none %}
@@ -84,7 +85,7 @@
     {% for reply in post.children %}
       <div class="mt-3 ms-3 border-start ps-3" id="post{{ reply.id }}">
         {% if reply.deleted %}
-        <p class="fst-italic text-muted">This post has been deleted</p>
+        <p class="fst-italic text-muted">This post has been deleted{% if reply.delete_reason %}: {{ reply.delete_reason }}{% endif %}</p>
         {% else %}
         <h6>{{ reply.title }} <small class="text-muted">by <a href="{{ url_for('main.profile', username=reply.author.username, thread_id=post.id) }}">{{ reply.author.username }}</a>
             {% if reply.author.is_moderator %}<span class="badge bg-primary">Mod</span>{% endif %}
@@ -102,8 +103,9 @@
         <div class="mb-2">
           <a href="{{ url_for('main.edit_post', post_id=reply.id) }}" class="btn btn-sm btn-outline-primary shortcut-edit">Edit</a>
           <a href="{{ url_for('main.post_history', post_id=reply.id) }}" class="btn btn-sm btn-outline-secondary">History</a>
-        <form method="post" action="{{ url_for('main.delete_post', post_id=reply.id) }}" class="d-inline">
+        <form method="post" action="{{ url_for('main.delete_post', post_id=reply.id) }}" class="d-inline delete-form">
           <input type="hidden" name="token" value="{{ action_token(reply.id) }}">
+          {% if current_user.is_moderator %}<input type="hidden" name="reason" value="">{% endif %}
           <button class="btn btn-sm btn-outline-danger" type="submit">Delete</button>
         </form>
         {% if current_user.is_moderator and current_user.id != reply.user_id %}

--- a/openbbs/templates/trash.html
+++ b/openbbs/templates/trash.html
@@ -5,6 +5,7 @@
   {% for post in posts %}
   <li class="list-group-item">
     <h5>{{ post.title }} <small class="text-muted">by {{ post.author.username }} at {{ post.timestamp.strftime('%Y-%m-%d %H:%M') }}</small></h5>
+    {% if post.delete_reason %}<p class="text-muted">Reason: {{ post.delete_reason }}</p>{% endif %}
     <form method="post" action="{{ url_for('main.restore_post', post_id=post.id) }}" class="d-inline">
       <input type="hidden" name="token" value="{{ action_token(post.id) }}">
       <button class="btn btn-sm btn-success" type="submit">Restore</button>

--- a/openbbs/views.py
+++ b/openbbs/views.py
@@ -1,4 +1,13 @@
-from flask import Blueprint, render_template, request, redirect, url_for, current_app, send_from_directory, send_file
+from flask import (
+    Blueprint,
+    render_template,
+    request,
+    redirect,
+    url_for,
+    current_app,
+    send_from_directory,
+    send_file,
+)
 import gzip
 import tempfile
 import io
@@ -13,12 +22,12 @@ from werkzeug.utils import secure_filename
 from pathlib import Path
 import markdown
 
-main_bp = Blueprint('main', __name__)
+main_bp = Blueprint("main", __name__)
 
 
 def _fernet() -> Fernet:
     """Return a Fernet instance using the app's encryption key."""
-    key = current_app.config['ENCRYPTION_KEY']
+    key = current_app.config["ENCRYPTION_KEY"]
     return Fernet(key)
 
 
@@ -45,7 +54,7 @@ def generate_action_token(post_id: int, user_id: int | None = None) -> str:
     """Return a signed token for actions on a post."""
     if user_id is None:
         user_id = current_user.id
-    key = current_app.config['SECRET_KEY'].encode()
+    key = current_app.config["SECRET_KEY"].encode()
     msg = f"{post_id}:{user_id}".encode()
     return hmac.new(key, msg, hashlib.sha256).hexdigest()
 
@@ -59,7 +68,7 @@ def verify_action_token(post_id: int, token: str, user_id: int | None = None) ->
 
 def generate_owner_token(post_id: int, user_id: int) -> str:
     """Return a signed token representing permanent thread ownership."""
-    key = current_app.config['SECRET_KEY'].encode()
+    key = current_app.config["SECRET_KEY"].encode()
     msg = f"owner:{post_id}:{user_id}".encode()
     return hmac.new(key, msg, hashlib.sha256).hexdigest()
 
@@ -72,72 +81,76 @@ def verify_owner_token(post: Post) -> bool:
     return hmac.compare_digest(expected, post.owner_token)
 
 
-@main_bp.route('/preview', methods=['POST'])
+@main_bp.route("/preview", methods=["POST"])
 @login_required
 def preview_markdown():
     """Return HTML preview for provided markdown text."""
-    text = request.get_json(force=True).get('text', '')
+    text = request.get_json(force=True).get("text", "")
     html = markdown.markdown(text)
-    return {'html': html}
+    return {"html": html}
 
 
-
-
-@main_bp.route('/')
+@main_bp.route("/")
 @login_required
 def index():
     forums = Forum.query.all()
-    return render_template('forums.html', forums=forums)
+    return render_template("forums.html", forums=forums)
 
 
-@main_bp.route('/post', methods=['POST'])
+@main_bp.route("/post", methods=["POST"])
 @login_required
 def create_post():
-    title = request.form.get('title')
-    body = request.form.get('body')
-    forum_id = request.form.get('forum_id', type=int)
-    parent_id = request.form.get('parent_id', type=int)
+    title = request.form.get("title")
+    body = request.form.get("body")
+    forum_id = request.form.get("forum_id", type=int)
+    parent_id = request.form.get("parent_id", type=int)
     if title and body and forum_id:
-        post = Post(title=title, body=body, author=current_user,
-                    forum_id=forum_id, parent_id=parent_id)
+        post = Post(
+            title=title,
+            body=body,
+            author=current_user,
+            forum_id=forum_id,
+            parent_id=parent_id,
+        )
         db.session.add(post)
         db.session.flush()  # to get id before committing
         if parent_id is None:
             post.owner_token = generate_owner_token(post.id, current_user.id)
-        file = request.files.get('attachment')
+        file = request.files.get("attachment")
         if file and file.filename:
             filename = secure_filename(file.filename)
-            upload_folder = Path(current_app.config['UPLOAD_FOLDER'])
+            upload_folder = Path(current_app.config["UPLOAD_FOLDER"])
             dest = upload_folder / f"{post.id}_{filename}.gz.enc"
             data = file.read()
             enc = encrypt_attachment(data)
-            with open(dest, 'wb') as f:
+            with open(dest, "wb") as f:
                 f.write(enc)
             att = Attachment(filename=str(dest), original_name=filename, post=post)
             db.session.add(att)
         db.session.commit()
         try:
             from .forums import get_forum_posts
+
             get_forum_posts.cache_clear()
         except Exception:
             pass
     if forum_id:
-        return redirect(url_for('forums.view_forum', forum_id=forum_id))
-    return redirect(url_for('main.index'))
+        return redirect(url_for("forums.view_forum", forum_id=forum_id))
+    return redirect(url_for("main.index"))
 
 
-@main_bp.route('/post/<int:post_id>/edit', methods=['GET', 'POST'])
+@main_bp.route("/post/<int:post_id>/edit", methods=["GET", "POST"])
 @login_required
 def edit_post(post_id):
     post = Post.query.get_or_404(post_id)
     if not _can_modify(post) or post.deleted:
-        return redirect(url_for('forums.view_forum', forum_id=post.forum_id))
-    if request.method == 'POST':
-        token = request.form.get('token')
+        return redirect(url_for("forums.view_forum", forum_id=post.forum_id))
+    if request.method == "POST":
+        token = request.form.get("token")
         if not verify_action_token(post.id, token):
-            return redirect(url_for('forums.view_forum', forum_id=post.forum_id))
-        title = request.form.get('title')
-        body = request.form.get('body')
+            return redirect(url_for("forums.view_forum", forum_id=post.forum_id))
+        title = request.form.get("title")
+        body = request.form.get("body")
         if title and body:
             ver = PostVersion(title=post.title, body=post.body, post=post)
             db.session.add(ver)
@@ -147,23 +160,26 @@ def edit_post(post_id):
             db.session.commit()
             try:
                 from .forums import get_forum_posts
+
                 get_forum_posts.cache_clear()
             except Exception:
                 pass
-            return redirect(url_for('forums.view_forum', forum_id=post.forum_id))
+            return redirect(url_for("forums.view_forum", forum_id=post.forum_id))
     token = generate_action_token(post.id)
-    return render_template('edit_post.html', post=post, token=token)
+    return render_template("edit_post.html", post=post, token=token)
 
 
-@main_bp.route('/post/<int:post_id>/delete', methods=['POST'])
+@main_bp.route("/post/<int:post_id>/delete", methods=["POST"])
 @login_required
 def delete_post(post_id):
     post = Post.query.get_or_404(post_id)
     if not _can_modify(post):
-        return redirect(url_for('forums.view_forum', forum_id=post.forum_id))
-    token = request.form.get('token')
+        return redirect(url_for("forums.view_forum", forum_id=post.forum_id))
+    token = request.form.get("token")
     if not verify_action_token(post.id, token):
-        return redirect(url_for('forums.view_forum', forum_id=post.forum_id))
+        return redirect(url_for("forums.view_forum", forum_id=post.forum_id))
+    reason = request.form.get("reason") if current_user.is_moderator else None
+
     def _delete_recursive(p: Post, hard: bool):
         for child in list(p.children):
             _delete_recursive(child, hard)
@@ -177,59 +193,76 @@ def delete_post(post_id):
             db.session.delete(p)
         else:
             p.deleted = True
+            if p is post and reason:
+                p.delete_reason = reason
 
+    if reason and current_user.is_moderator:
+        note = ModNote(
+            text=f"Deleted: {reason}",
+            user_id=post.user_id,
+            mod_id=current_user.id,
+            post_id=post.id,
+        )
+        db.session.add(note)
     _delete_recursive(post, current_user.is_moderator)
     db.session.commit()
     try:
         from .forums import get_forum_posts
+
         get_forum_posts.cache_clear()
     except Exception:
         pass
-    return redirect(url_for('forums.view_forum', forum_id=post.forum_id))
+    return redirect(url_for("forums.view_forum", forum_id=post.forum_id))
 
 
-@main_bp.route('/post/<int:post_id>/restore', methods=['POST'])
+@main_bp.route("/post/<int:post_id>/restore", methods=["POST"])
 @login_required
 def restore_post(post_id):
     post = Post.query.get_or_404(post_id)
     if not current_user.is_moderator:
-        return redirect(url_for('forums.view_forum', forum_id=post.forum_id))
-    token = request.form.get('token')
+        return redirect(url_for("forums.view_forum", forum_id=post.forum_id))
+    token = request.form.get("token")
     if not verify_action_token(post.id, token):
-        return redirect(url_for('main.trash'))
+        return redirect(url_for("main.trash"))
     post.deleted = False
+    post.delete_reason = None
     db.session.commit()
     try:
         from .forums import get_forum_posts
+
         get_forum_posts.cache_clear()
     except Exception:
         pass
-    return redirect(url_for('main.trash'))
+    return redirect(url_for("main.trash"))
 
 
-@main_bp.route('/post/<int:post_id>/history')
+@main_bp.route("/post/<int:post_id>/history")
 @login_required
 def post_history(post_id):
     post = Post.query.get_or_404(post_id)
     if post.deleted:
-        return redirect(url_for('forums.view_forum', forum_id=post.forum_id))
-    versions = PostVersion.query.filter_by(post_id=post.id).order_by(PostVersion.timestamp.desc()).all()
+        return redirect(url_for("forums.view_forum", forum_id=post.forum_id))
+    versions = (
+        PostVersion.query.filter_by(post_id=post.id)
+        .order_by(PostVersion.timestamp.desc())
+        .all()
+    )
     token = generate_action_token(post.id)
-    return render_template('history.html', post=post, versions=versions, token=token)
+    return render_template("history.html", post=post, versions=versions, token=token)
 
 
-@main_bp.route('/post/<int:post_id>/revert/<int:ver_id>', methods=['POST'])
+@main_bp.route("/post/<int:post_id>/revert/<int:ver_id>", methods=["POST"])
 @login_required
 def revert_post(post_id, ver_id):
     post = Post.query.get_or_404(post_id)
     if not _can_modify(post) or post.deleted:
-        return redirect(url_for('forums.view_forum', forum_id=post.forum_id))
-    token = request.form.get('token')
+        return redirect(url_for("forums.view_forum", forum_id=post.forum_id))
+    token = request.form.get("token")
     if not verify_action_token(post.id, token):
-        return redirect(url_for('forums.view_forum', forum_id=post.forum_id))
+        return redirect(url_for("forums.view_forum", forum_id=post.forum_id))
     ver = PostVersion.query.get_or_404(ver_id)
     if ver.post_id != post.id:
-        return redirect(url_for('forums.view_forum', forum_id=post.forum_id))
+        return redirect(url_for("forums.view_forum", forum_id=post.forum_id))
     new_ver = PostVersion(title=post.title, body=post.body, post=post)
     db.session.add(new_ver)
     post.title = ver.title
@@ -238,254 +271,343 @@ def revert_post(post_id, ver_id):
     db.session.commit()
     try:
         from .forums import get_forum_posts
+
         get_forum_posts.cache_clear()
     except Exception:
         pass
-    return redirect(url_for('main.post_history', post_id=post.id))
+    return redirect(url_for("main.post_history", post_id=post.id))
 
 
-@main_bp.route('/post/<int:post_id>/flag', methods=['POST'])
+@main_bp.route("/post/<int:post_id>/flag", methods=["POST"])
 @login_required
 def flag_post(post_id):
     post = Post.query.get_or_404(post_id)
-    token = request.form.get('token')
+    token = request.form.get("token")
     if not verify_action_token(post.id, token):
-        return redirect(url_for('forums.view_forum', forum_id=post.forum_id))
-    reason = request.form.get('reason') or ''
+        return redirect(url_for("forums.view_forum", forum_id=post.forum_id))
+    reason = request.form.get("reason") or ""
     flag = Flag(post=post, reporter=current_user, reason=reason)
     db.session.add(flag)
     db.session.commit()
-    return redirect(url_for('forums.view_forum', forum_id=post.forum_id))
+    return redirect(url_for("forums.view_forum", forum_id=post.forum_id))
 
 
-@main_bp.route('/post/<int:post_id>/pin', methods=['POST'])
+@main_bp.route("/post/<int:post_id>/pin", methods=["POST"])
 @login_required
 def pin_post(post_id):
     post = Post.query.get_or_404(post_id)
     if not current_user.is_moderator or post.parent_id is not None:
-        return redirect(url_for('forums.view_forum', forum_id=post.forum_id))
-    token = request.form.get('token')
+        return redirect(url_for("forums.view_forum", forum_id=post.forum_id))
+    token = request.form.get("token")
     if not verify_action_token(post.id, token):
-        return redirect(url_for('forums.view_forum', forum_id=post.forum_id))
+        return redirect(url_for("forums.view_forum", forum_id=post.forum_id))
     post.is_pinned = True
     db.session.commit()
     try:
         from .forums import get_forum_posts
+
         get_forum_posts.cache_clear()
     except Exception:
         pass
-    return redirect(url_for('forums.view_forum', forum_id=post.forum_id))
+    return redirect(url_for("forums.view_forum", forum_id=post.forum_id))
 
 
-@main_bp.route('/post/<int:post_id>/unpin', methods=['POST'])
+@main_bp.route("/post/<int:post_id>/unpin", methods=["POST"])
 @login_required
 def unpin_post(post_id):
     post = Post.query.get_or_404(post_id)
     if not current_user.is_moderator or post.parent_id is not None:
-        return redirect(url_for('forums.view_forum', forum_id=post.forum_id))
-    token = request.form.get('token')
+        return redirect(url_for("forums.view_forum", forum_id=post.forum_id))
+    token = request.form.get("token")
     if not verify_action_token(post.id, token):
-        return redirect(url_for('forums.view_forum', forum_id=post.forum_id))
+        return redirect(url_for("forums.view_forum", forum_id=post.forum_id))
     post.is_pinned = False
     db.session.commit()
     try:
         from .forums import get_forum_posts
+
         get_forum_posts.cache_clear()
     except Exception:
         pass
-    return redirect(url_for('forums.view_forum', forum_id=post.forum_id))
+    return redirect(url_for("forums.view_forum", forum_id=post.forum_id))
 
 
-@main_bp.route('/post/<int:post_id>/lock', methods=['POST'])
+@main_bp.route("/post/<int:post_id>/lock", methods=["POST"])
 @login_required
 def lock_post(post_id):
     post = Post.query.get_or_404(post_id)
     if post.parent_id is not None:
-        return redirect(url_for('forums.view_forum', forum_id=post.forum_id))
-    allowed = current_user.is_moderator or (current_user.id == post.user_id and verify_owner_token(post))
+        return redirect(url_for("forums.view_forum", forum_id=post.forum_id))
+    allowed = current_user.is_moderator or (
+        current_user.id == post.user_id and verify_owner_token(post)
+    )
     if not allowed:
-        return redirect(url_for('forums.view_forum', forum_id=post.forum_id))
-    token = request.form.get('token')
+        return redirect(url_for("forums.view_forum", forum_id=post.forum_id))
+    token = request.form.get("token")
     if not verify_action_token(post.id, token):
-        return redirect(url_for('forums.view_forum', forum_id=post.forum_id))
+        return redirect(url_for("forums.view_forum", forum_id=post.forum_id))
     post.is_locked = True
     db.session.commit()
     try:
         from .forums import get_forum_posts
+
         get_forum_posts.cache_clear()
     except Exception:
         pass
-    return redirect(url_for('forums.view_forum', forum_id=post.forum_id))
+    return redirect(url_for("forums.view_forum", forum_id=post.forum_id))
 
 
-@main_bp.route('/post/<int:post_id>/unlock', methods=['POST'])
+@main_bp.route("/post/<int:post_id>/unlock", methods=["POST"])
 @login_required
 def unlock_post(post_id):
     post = Post.query.get_or_404(post_id)
     if post.parent_id is not None:
-        return redirect(url_for('forums.view_forum', forum_id=post.forum_id))
-    allowed = current_user.is_moderator or (current_user.id == post.user_id and verify_owner_token(post))
+        return redirect(url_for("forums.view_forum", forum_id=post.forum_id))
+    allowed = current_user.is_moderator or (
+        current_user.id == post.user_id and verify_owner_token(post)
+    )
     if not allowed:
-        return redirect(url_for('forums.view_forum', forum_id=post.forum_id))
-    token = request.form.get('token')
+        return redirect(url_for("forums.view_forum", forum_id=post.forum_id))
+    token = request.form.get("token")
     if not verify_action_token(post.id, token):
-        return redirect(url_for('forums.view_forum', forum_id=post.forum_id))
+        return redirect(url_for("forums.view_forum", forum_id=post.forum_id))
     post.is_locked = False
     db.session.commit()
     try:
         from .forums import get_forum_posts
+
         get_forum_posts.cache_clear()
     except Exception:
         pass
-    return redirect(url_for('forums.view_forum', forum_id=post.forum_id))
+    return redirect(url_for("forums.view_forum", forum_id=post.forum_id))
 
 
-@main_bp.route('/post/<int:post_id>/move', methods=['GET', 'POST'])
+@main_bp.route("/post/<int:post_id>/move", methods=["GET", "POST"])
 @login_required
 def move_post(post_id):
     post = Post.query.get_or_404(post_id)
     if post.parent_id is not None:
-        return redirect(url_for('forums.view_forum', forum_id=post.forum_id))
+        return redirect(url_for("forums.view_forum", forum_id=post.forum_id))
     if not current_user.is_moderator:
-        return redirect(url_for('forums.view_forum', forum_id=post.forum_id))
-    if request.method == 'POST':
-        token = request.form.get('token')
+        return redirect(url_for("forums.view_forum", forum_id=post.forum_id))
+    if request.method == "POST":
+        token = request.form.get("token")
         if not verify_action_token(post.id, token):
-            return redirect(url_for('forums.view_forum', forum_id=post.forum_id))
-        forum_id = request.form.get('forum_id', type=int)
+            return redirect(url_for("forums.view_forum", forum_id=post.forum_id))
+        forum_id = request.form.get("forum_id", type=int)
         forum = Forum.query.get(forum_id)
         if forum:
+
             def _move_recursive(p: Post):
                 p.forum_id = forum_id
                 for child in p.children:
                     _move_recursive(child)
+
             _move_recursive(post)
             db.session.commit()
             try:
                 from .forums import get_forum_posts
+
                 get_forum_posts.cache_clear()
             except Exception:
                 pass
-            return redirect(url_for('forums.view_forum', forum_id=forum_id))
+            return redirect(url_for("forums.view_forum", forum_id=forum_id))
     forums = Forum.query.all()
     token = generate_action_token(post.id)
-    return render_template('move_post.html', post=post, forums=forums, token=token)
+    return render_template("move_post.html", post=post, forums=forums, token=token)
 
 
-@main_bp.route('/attachment/<int:att_id>')
+@main_bp.route("/attachment/<int:att_id>")
 @login_required
 def get_attachment(att_id):
     """Return the attachment file, decrypting and decompressing if needed."""
     att = Attachment.query.get_or_404(att_id)
     path = Path(att.filename)
-    if path.suffix == '.enc':
+    if path.suffix == ".enc":
         data = path.read_bytes()
         data = decrypt_attachment(data)
-        return send_file(io.BytesIO(data), as_attachment=True,
-                         download_name=att.original_name)
-    if path.suffix == '.gz':
-        with gzip.open(path, 'rb') as f:
+        return send_file(
+            io.BytesIO(data), as_attachment=True, download_name=att.original_name
+        )
+    if path.suffix == ".gz":
+        with gzip.open(path, "rb") as f:
             data = f.read()
-        return send_file(io.BytesIO(data), as_attachment=True,
-                         download_name=att.original_name)
-    return send_from_directory(path.parent, path.name, as_attachment=True,
-                               download_name=att.original_name)
+        return send_file(
+            io.BytesIO(data), as_attachment=True, download_name=att.original_name
+        )
+    return send_from_directory(
+        path.parent, path.name, as_attachment=True, download_name=att.original_name
+    )
 
 
-@main_bp.route('/profile/<username>')
+@main_bp.route("/profile/<username>")
 @login_required
 def profile(username):
     user = User.query.filter_by(username=username).first_or_404()
-    posts = Post.query.filter_by(user_id=user.id, deleted=False).order_by(Post.timestamp.desc()).all()
-    thread_id = request.args.get('thread_id', type=int)
+    posts = (
+        Post.query.filter_by(user_id=user.id, deleted=False)
+        .order_by(Post.timestamp.desc())
+        .all()
+    )
+    thread_id = request.args.get("thread_id", type=int)
     owner = False
     if thread_id:
         thread = Post.query.get(thread_id)
         if thread and thread.parent_id is None and thread.user_id == current_user.id:
             owner = verify_owner_token(thread)
     token = generate_action_token(user.id)
-    return render_template('profile.html', user=user, posts=posts, token=token, owner=owner, thread_id=thread_id)
+    return render_template(
+        "profile.html",
+        user=user,
+        posts=posts,
+        token=token,
+        owner=owner,
+        thread_id=thread_id,
+    )
 
 
-@main_bp.route('/user/<int:user_id>/toggle_mod', methods=['POST'])
+@main_bp.route("/user/<int:user_id>/toggle_mod", methods=["POST"])
 @login_required
 def toggle_mod(user_id):
-    thread_id = request.form.get('thread_id', type=int)
+    thread_id = request.form.get("thread_id", type=int)
     allowed = current_user.is_moderator
     if not allowed and thread_id:
         thread = Post.query.get(thread_id)
         if thread and thread.parent_id is None and thread.user_id == current_user.id:
             allowed = verify_owner_token(thread)
     if not allowed:
-        return redirect(url_for('main.profile', username=current_user.username))
+        return redirect(url_for("main.profile", username=current_user.username))
     user = User.query.get_or_404(user_id)
-    token = request.form.get('token')
+    token = request.form.get("token")
     if not verify_action_token(user.id, token):
-        return redirect(url_for('main.profile', username=user.username))
+        return redirect(url_for("main.profile", username=user.username))
     user.is_moderator = not user.is_moderator
     db.session.commit()
     args = {}
     if thread_id:
-        args['thread_id'] = thread_id
-    return redirect(url_for('main.profile', username=user.username, **args))
+        args["thread_id"] = thread_id
+    return redirect(url_for("main.profile", username=user.username, **args))
 
 
-@main_bp.route('/user/<int:user_id>/warn', methods=['POST'])
+@main_bp.route("/user/<int:user_id>/warn", methods=["POST"])
 @login_required
 def warn_user(user_id):
     if not current_user.is_moderator:
-        return redirect(url_for('main.profile', username=current_user.username))
+        return redirect(url_for("main.profile", username=current_user.username))
     user = User.query.get_or_404(user_id)
-    token = request.form.get('token')
+    token = request.form.get("token")
     if not verify_action_token(user.id, token):
-        return redirect(url_for('main.profile', username=user.username))
-    text = request.form.get('text') or ''
-    post_id = request.form.get('post_id', type=int)
-    note = ModNote(text=text, user_id=user.id, mod_id=current_user.id,
-                   post_id=post_id)
+        return redirect(url_for("main.profile", username=user.username))
+    text = request.form.get("text") or ""
+    post_id = request.form.get("post_id", type=int)
+    note = ModNote(text=text, user_id=user.id, mod_id=current_user.id, post_id=post_id)
     db.session.add(note)
     db.session.commit()
-    return redirect(url_for('main.profile', username=user.username))
+    return redirect(url_for("main.profile", username=user.username))
 
 
-@main_bp.route('/trash')
+@main_bp.route("/trash")
 @login_required
 def trash():
     if not current_user.is_moderator:
-        return redirect(url_for('main.index'))
+        return redirect(url_for("main.index"))
     posts = Post.query.filter_by(deleted=True).order_by(Post.timestamp.desc()).all()
-    return render_template('trash.html', posts=posts)
+    return render_template("trash.html", posts=posts)
 
 
-@main_bp.route('/flags')
+@main_bp.route("/flags")
 @login_required
 def flags():
     if not current_user.is_moderator:
-        return redirect(url_for('main.index'))
+        return redirect(url_for("main.index"))
     flags = Flag.query.filter_by(resolved=False).order_by(Flag.timestamp.desc()).all()
-    return render_template('flags.html', flags=flags)
+    return render_template("flags.html", flags=flags)
 
 
-@main_bp.route('/flag/<int:flag_id>/resolve', methods=['POST'])
+@main_bp.route("/flag/<int:flag_id>/resolve", methods=["POST"])
 @login_required
 def resolve_flag(flag_id):
     if not current_user.is_moderator:
-        return redirect(url_for('main.index'))
+        return redirect(url_for("main.index"))
     flg = Flag.query.get_or_404(flag_id)
     flg.resolved = True
     db.session.commit()
-    return redirect(url_for('main.flags'))
+    return redirect(url_for("main.flags"))
 
 
-@main_bp.route('/search')
+@main_bp.route("/flag/<int:flag_id>/delete", methods=["POST"])
+@login_required
+def delete_flagged_post(flag_id):
+    """Delete a flagged post and mark the flag resolved."""
+    if not current_user.is_moderator:
+        return redirect(url_for("main.index"))
+    flg = Flag.query.get_or_404(flag_id)
+    token = request.form.get("token")
+    if not verify_action_token(flg.post.id, token):
+        return redirect(url_for("main.flags"))
+    reason = request.form.get("reason") or ""
+    if reason:
+        note = ModNote(
+            text=f"Deleted (flagged): {reason}",
+            user_id=flg.post.user_id,
+            mod_id=current_user.id,
+            post_id=flg.post.id,
+        )
+        db.session.add(note)
+
+    def _del_recursive(p: Post):
+        for ch in list(p.children):
+            _del_recursive(ch)
+        for att in list(p.attachments):
+            try:
+                Path(att.filename).unlink(missing_ok=True)
+            except Exception:
+                pass
+            db.session.delete(att)
+        for fl in list(p.flags):
+            db.session.delete(fl)
+        db.session.delete(p)
+
+    _del_recursive(flg.post)
+    db.session.delete(flg)
+    db.session.commit()
+    try:
+        from .forums import get_forum_posts
+
+        get_forum_posts.cache_clear()
+    except Exception:
+        pass
+    return redirect(url_for("main.flags"))
+
+
+@main_bp.route("/suggest")
+@login_required
+def suggest():
+    q = request.args.get("q", "").strip()
+    results: list[dict] = []
+    if q:
+        like = f"%{q}%"
+        posts = (
+            Post.query.filter(
+                Post.title.ilike(like), Post.parent_id == None, Post.deleted == False
+            )
+            .order_by(Post.timestamp.desc())
+            .limit(5)
+            .all()
+        )
+        results = [{"id": p.id, "title": p.title} for p in posts]
+    return {"results": results}
+
+
+@main_bp.route("/search")
 @login_required
 def search():
-    query = request.args.get('q', '').strip()
-    author_q = request.args.get('author', '').strip()
-    forum_id = request.args.get('forum_id', type=int)
-    start = request.args.get('start')
-    end = request.args.get('end')
-    sort = request.args.get('sort', 'newest')
+    query = request.args.get("q", "").strip()
+    author_q = request.args.get("author", "").strip()
+    forum_id = request.args.get("forum_id", type=int)
+    start = request.args.get("start")
+    end = request.args.get("end")
+    sort = request.args.get("sort", "newest")
     results = []
     if query:
         like = f"%{query}%"
@@ -510,13 +632,20 @@ def search():
             user = User.query.filter(User.username.ilike(author_q)).first()
             if user:
                 q = q.filter(Post.user_id == user.id)
-        if sort == 'oldest':
+        if sort == "oldest":
             q = q.order_by(Post.timestamp.asc())
-        elif sort == 'replies':
+        elif sort == "replies":
             from sqlalchemy import func
-            q = q.outerjoin(Post.children).group_by(Post.id).order_by(func.count(Post.id).desc())
+
+            q = (
+                q.outerjoin(Post.children)
+                .group_by(Post.id)
+                .order_by(func.count(Post.id).desc())
+            )
         else:
             q = q.order_by(Post.timestamp.desc())
         results = q.all()
     forums = Forum.query.all()
-    return render_template('search.html', query=query, results=results, forums=forums, sort=sort)
+    return render_template(
+        "search.html", query=query, results=results, forums=forums, sort=sort
+    )

--- a/tests/test_flag_delete.py
+++ b/tests/test_flag_delete.py
@@ -1,0 +1,54 @@
+from openbbs import create_app, db
+from openbbs.models import User, Forum, Post, Flag, ModNote
+from openbbs.views import generate_action_token
+import pytest
+
+
+@pytest.fixture
+def app_ctx(tmp_path):
+    app = create_app()
+    app.config["SQLALCHEMY_DATABASE_URI"] = f'sqlite:///{tmp_path / "test.db"}'
+    app.config["TESTING"] = True
+    with app.app_context():
+        db.create_all()
+        yield app
+
+
+@pytest.fixture
+def client(app_ctx):
+    return app_ctx.test_client()
+
+
+def create_user(username, is_mod=False):
+    user = User(username=username, password="pw", is_moderator=is_mod)
+    db.session.add(user)
+    db.session.commit()
+    return user
+
+
+def login(client, username):
+    with client.session_transaction() as sess:
+        sess["_user_id"] = str(User.query.filter_by(username=username).first().id)
+
+
+def test_delete_flagged_post(app_ctx, client):
+    mod = create_user("mod", is_mod=True)
+    user = create_user("bob")
+    forum = Forum(name="f1")
+    db.session.add(forum)
+    db.session.commit()
+    post = Post(title="t", body="b", author=user, forum=forum)
+    db.session.add(post)
+    db.session.commit()
+    flag = Flag(post=post, reporter=user, reason="spam")
+    db.session.add(flag)
+    db.session.commit()
+    login(client, "mod")
+    token = generate_action_token(post.id, mod.id)
+    resp = client.post(
+        f"/flag/{flag.id}/delete", data={"token": token, "reason": "bad"}
+    )
+    assert resp.status_code == 302
+    assert Post.query.get(post.id) is None
+    note = ModNote.query.filter_by(post_id=post.id).first()
+    assert note is not None and "bad" in note.text

--- a/tests/test_post_edit.py
+++ b/tests/test_post_edit.py
@@ -3,14 +3,16 @@ from openbbs.models import User, Forum, Post
 from openbbs.views import generate_action_token
 import pytest
 
+
 @pytest.fixture
 def app_ctx(tmp_path):
     app = create_app()
-    app.config['SQLALCHEMY_DATABASE_URI'] = f'sqlite:///{tmp_path / "test.db"}'
-    app.config['TESTING'] = True
+    app.config["SQLALCHEMY_DATABASE_URI"] = f'sqlite:///{tmp_path / "test.db"}'
+    app.config["TESTING"] = True
     with app.app_context():
         db.create_all()
         yield app
+
 
 @pytest.fixture
 def client(app_ctx):
@@ -18,7 +20,7 @@ def client(app_ctx):
 
 
 def create_user(username, is_mod=False):
-    user = User(username=username, password='pw', is_moderator=is_mod)
+    user = User(username=username, password="pw", is_moderator=is_mod)
     db.session.add(user)
     db.session.commit()
     return user
@@ -26,97 +28,102 @@ def create_user(username, is_mod=False):
 
 def login(client, username):
     with client.session_transaction() as sess:
-        sess['_user_id'] = str(User.query.filter_by(username=username).first().id)
+        sess["_user_id"] = str(User.query.filter_by(username=username).first().id)
 
 
 def test_edit_post_updates_timestamp(app_ctx, client):
-    user = create_user('alice')
-    forum = Forum(name='f1')
+    user = create_user("alice")
+    forum = Forum(name="f1")
     db.session.add(forum)
     db.session.commit()
-    post = Post(title='t', body='b', author=user, forum=forum)
+    post = Post(title="t", body="b", author=user, forum=forum)
     db.session.add(post)
     db.session.commit()
-    login(client, 'alice')
+    login(client, "alice")
     token = generate_action_token(post.id, user.id)
-    resp = client.post(f'/post/{post.id}/edit', data={'title': 't2', 'body': 'b2', 'token': token})
+    resp = client.post(
+        f"/post/{post.id}/edit", data={"title": "t2", "body": "b2", "token": token}
+    )
     assert resp.status_code == 302
     updated = Post.query.get(post.id)
-    assert updated.title == 't2'
+    assert updated.title == "t2"
     assert updated.edited_at is not None
 
 
 def test_soft_delete_for_user(app_ctx, client):
-    user = create_user('bob')
-    forum = Forum(name='f2')
+    user = create_user("bob")
+    forum = Forum(name="f2")
     db.session.add(forum)
     db.session.commit()
-    post = Post(title='t', body='b', author=user, forum=forum)
+    post = Post(title="t", body="b", author=user, forum=forum)
     db.session.add(post)
     db.session.commit()
-    login(client, 'bob')
+    login(client, "bob")
     token = generate_action_token(post.id, user.id)
-    resp = client.post(f'/post/{post.id}/delete', data={'token': token})
+    resp = client.post(f"/post/{post.id}/delete", data={"token": token})
     assert resp.status_code == 302
     assert Post.query.get(post.id).deleted
 
 
 def test_hard_delete_for_moderator(app_ctx, client):
-    mod = create_user('mod', is_mod=True)
-    user = create_user('user')
-    forum = Forum(name='f3')
+    mod = create_user("mod", is_mod=True)
+    user = create_user("user")
+    forum = Forum(name="f3")
     db.session.add(forum)
     db.session.commit()
-    post = Post(title='t', body='b', author=user, forum=forum)
+    post = Post(title="t", body="b", author=user, forum=forum)
     db.session.add(post)
     db.session.commit()
-    login(client, 'mod')
+    login(client, "mod")
     token = generate_action_token(post.id, mod.id)
-    resp = client.post(f'/post/{post.id}/delete', data={'token': token})
+    resp = client.post(f"/post/{post.id}/delete", data={"token": token})
     assert resp.status_code == 302
     assert Post.query.get(post.id) is None
 
 
 def test_invalid_token_prevents_edit(app_ctx, client):
-    user = create_user('carol')
-    forum = Forum(name='f4')
+    user = create_user("carol")
+    forum = Forum(name="f4")
     db.session.add(forum)
     db.session.commit()
-    post = Post(title='t', body='b', author=user, forum=forum)
+    post = Post(title="t", body="b", author=user, forum=forum)
     db.session.add(post)
     db.session.commit()
-    login(client, 'carol')
-    resp = client.post(f'/post/{post.id}/edit', data={'title': 'x', 'body': 'y', 'token': 'bad'})
+    login(client, "carol")
+    resp = client.post(
+        f"/post/{post.id}/edit", data={"title": "x", "body": "y", "token": "bad"}
+    )
     assert resp.status_code == 302
-    assert Post.query.get(post.id).title == 't'
+    assert Post.query.get(post.id).title == "t"
 
 
 def test_invalid_token_prevents_delete(app_ctx, client):
-    user = create_user('dave')
-    forum = Forum(name='f5')
+    user = create_user("dave")
+    forum = Forum(name="f5")
     db.session.add(forum)
     db.session.commit()
-    post = Post(title='t', body='b', author=user, forum=forum)
+    post = Post(title="t", body="b", author=user, forum=forum)
     db.session.add(post)
     db.session.commit()
-    login(client, 'dave')
-    resp = client.post(f'/post/{post.id}/delete', data={'token': 'bad'})
+    login(client, "dave")
+    resp = client.post(f"/post/{post.id}/delete", data={"token": "bad"})
     assert resp.status_code == 302
     assert not Post.query.get(post.id).deleted
 
 
 def test_restore_post(app_ctx, client):
-    mod = create_user('rest_mod', is_mod=True)
-    user = create_user('frank')
-    forum = Forum(name='f6')
+    mod = create_user("rest_mod", is_mod=True)
+    user = create_user("frank")
+    forum = Forum(name="f6")
     db.session.add(forum)
     db.session.commit()
-    post = Post(title='t', body='b', author=user, forum=forum, deleted=True)
+    post = Post(title="t", body="b", author=user, forum=forum, deleted=True)
     db.session.add(post)
     db.session.commit()
-    login(client, 'rest_mod')
+    login(client, "rest_mod")
     token = generate_action_token(post.id, mod.id)
-    resp = client.post(f'/post/{post.id}/restore', data={'token': token})
+    resp = client.post(f"/post/{post.id}/restore", data={"token": token})
     assert resp.status_code == 302
-    assert not Post.query.get(post.id).deleted
-
+    restored = Post.query.get(post.id)
+    assert not restored.deleted
+    assert restored.delete_reason is None


### PR DESCRIPTION
## Summary
- log deletion reasons and show them in trash
- allow mods to delete flagged posts with reasons
- add `/suggest` endpoint for search autocompletion
- show search suggestions in navbar
- ask for deletion reason via JS prompt
- include tests for new deletion flows

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687fd1481c90832ab983fd42ae89f064