### PR TITLE
Implement post splitting

### DIFF
--- a/openbbs/templates/forum_view.html
+++ b/openbbs/templates/forum_view.html
@@ -115,6 +115,7 @@
           <input type="hidden" name="text" value="">
           <button class="btn btn-sm btn-outline-warning" type="submit">Warn</button>
         </form>
+        <a href="{{ url_for('main.split_post', post_id=reply.id) }}" class="btn btn-sm btn-outline-secondary ms-1">Split</a>
         {% endif %}
       </div>
       {% endif %}

--- a/openbbs/templates/split_post.html
+++ b/openbbs/templates/split_post.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Split Post</h2>
+<form method="post">
+  <input type="hidden" name="token" value="{{ token }}">
+  <div class="mb-3">
+    <label class="form-label" for="forum_id">Destination Forum</label>
+    <select class="form-select" name="forum_id" id="forum_id" required>
+      {% for f in forums %}
+      <option value="{{ f.id }}" {% if f.id == post.forum_id %}selected{% endif %}>{{ f.name }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <button class="btn btn-primary" type="submit">Split</button>
+  <a class="btn btn-secondary" href="{{ url_for('forums.view_forum', forum_id=post.forum_id) }}">Cancel</a>
+</form>
+{% endblock %}

--- a/tests/test_split_post.py
+++ b/tests/test_split_post.py
@@ -1,0 +1,53 @@
+from openbbs import create_app, db
+from openbbs.models import User, Forum, Post
+from openbbs.views import generate_action_token, generate_owner_token, verify_owner_token
+import pytest
+
+@pytest.fixture
+def app_ctx(tmp_path):
+    app = create_app()
+    app.config['SQLALCHEMY_DATABASE_URI'] = f'sqlite:///{tmp_path / "test.db"}'
+    app.config['TESTING'] = True
+    with app.app_context():
+        db.create_all()
+        yield app
+
+@pytest.fixture
+def client(app_ctx):
+    return app_ctx.test_client()
+
+
+def create_user(username, is_mod=False):
+    user = User(username=username, password='pw', is_moderator=is_mod)
+    db.session.add(user)
+    db.session.commit()
+    return user
+
+
+def login(client, username):
+    with client.session_transaction() as sess:
+        sess['_user_id'] = str(User.query.filter_by(username=username).first().id)
+
+
+def test_split_post(app_ctx, client):
+    mod = create_user('mod', is_mod=True)
+    author = create_user('author')
+    forum1 = Forum(name='f1')
+    forum2 = Forum(name='f2')
+    db.session.add_all([forum1, forum2])
+    db.session.commit()
+    root = Post(title='root', body='b', author=author, forum=forum1)
+    db.session.add(root)
+    db.session.flush()
+    root.owner_token = generate_owner_token(root.id, author.id)
+    reply = Post(title='reply', body='r', author=author, forum=forum1, parent_id=root.id)
+    db.session.add(reply)
+    db.session.commit()
+    login(client, 'mod')
+    token = generate_action_token(reply.id, mod.id)
+    resp = client.post(f'/post/{reply.id}/split', data={'forum_id': forum2.id, 'token': token})
+    assert resp.status_code == 302
+    sp = Post.query.get(reply.id)
+    assert sp.parent_id is None
+    assert sp.forum_id == forum2.id
+    assert verify_owner_token(sp)


### PR DESCRIPTION
## Summary
- enable splitting replies into new topics
- show `Split` option in moderator tools
- add `split_post` view and template
- test splitting functionality

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687fd3ba89a0832aaa28d531c40fb51e