### PR TITLE
Ensure attachments stored without encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Additional usage information is available in [docs/USAGE.md](docs/USAGE.md).
 
 - User signup and login
 - Forums with threads and replies
-- File attachments on posts with encrypted gzip compression
+- File attachments on posts with gzip compression (no encryption)
 - SQLite database via SQLAlchemy
 - Simple web interface using Bootstrap
 - Synchronization API and CLI tools
@@ -52,4 +52,4 @@ python bbs.py sync push package.tar.zst
 
 ## Notes
 
-Radio communication supports the VaraHF modem over TCP and includes a KISS TNC compatibility layer. The `VaraKISS` helper lets you talk to VARA Terminal in its KISS serial mode. File attachments are encrypted and compressed for safe transfer.
+Radio communication supports the VaraHF modem over TCP and includes a KISS TNC compatibility layer. The `VaraKISS` helper lets you talk to VARA Terminal in its KISS serial mode. File attachments are gzip compressed for safe transfer and are stored unencrypted.

--- a/tests/test_attachment_encrypt.py
+++ b/tests/test_attachment_encrypt.py
@@ -1,14 +1,12 @@
 from flask import Flask
 from openbbs.views import encrypt_attachment, decrypt_attachment
-from cryptography.fernet import Fernet
 
 
 def test_encrypt_decrypt_roundtrip():
     app = Flask(__name__)
-    app.config['ENCRYPTION_KEY'] = Fernet.generate_key()
     with app.app_context():
         data = b"secret data"
-        enc = encrypt_attachment(data)
-        dec = decrypt_attachment(enc)
+        comp = encrypt_attachment(data)
+        dec = decrypt_attachment(comp)
         assert dec == data
 


### PR DESCRIPTION
## Summary
- remove Fernet-based attachment encryption
- save attachments using only gzip compression
- adjust download handler accordingly
- update docs and tests for no encryption

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6880ebcbb744832a894945abe9cb4e56