### PR TITLE
Improve run script dependency error

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,3 +1,30 @@
+import sys
+
+MISSING = []
+for pkg in [
+    "flask",
+    "flask_sqlalchemy",
+    "flask_login",
+    "werkzeug",
+    "zstandard",
+    "pyserial",
+    "reedsolo",
+    "crcmod",
+    "cryptography",
+    "markdown",
+]:
+    try:
+        __import__(pkg.replace("-", "_"))
+    except ImportError:
+        MISSING.append(pkg)
+
+if MISSING:
+    missing_list = ", ".join(MISSING)
+    sys.exit(
+        f"Missing required packages: {missing_list}. "
+        "Run `pip install -r requirements.txt` to install them."
+    )
+
 from openbbs import create_app
 
 app = create_app()


### PR DESCRIPTION
## Summary
- add explicit dependency checks to `run.py` so running the app provides a clearer message if packages are missing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6880fbd8c624832ab34e263ac9f34757